### PR TITLE
Ensure all parsers are tested in CursorOptionTokenInfoTest

### DIFF
--- a/Test/SqlDom/RegressionTests.cs
+++ b/Test/SqlDom/RegressionTests.cs
@@ -174,7 +174,9 @@ WITH (MEMORY_OPTIMIZED = ON);";
 
                 using (var scriptReader = new StringReader(script))
                 {
-                    var fragment = Parse(scriptReader) as TSqlScript;
+                    var fragment = parser.Parse(scriptReader, out IList<ParseError> errors) as TSqlScript;
+                    Assert.AreEqual(0, errors.Count);
+
                     Assert.IsTrue(fragment is TSqlScript);
                     Assert.IsTrue(fragment.Batches[0].Statements[0] is DeclareCursorStatement);
 


### PR DESCRIPTION
The original implementation of the test was wrongly using the internal Parse() helper function, which only used TSql140Parser. Now, the test correctly uses the local `parser` class to ensure all parser versions are tested.