### PR TITLE
Fix gaps / inconsistencies in BACKUP / RESTORE device type

### DIFF
--- a/SqlScriptDom/Parser/TSql/DeviceType.cs
+++ b/SqlScriptDom/Parser/TSql/DeviceType.cs
@@ -18,7 +18,8 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom
         Disk = 1,
         Tape = 2,
         VirtualDevice = 3,
-        DatabaseSnapshot = 4
+        DatabaseSnapshot = 4,
+        Url = 5
     }
 
 #pragma warning restore 1591

--- a/SqlScriptDom/Parser/TSql/DeviceTypesHelper.cs
+++ b/SqlScriptDom/Parser/TSql/DeviceTypesHelper.cs
@@ -14,8 +14,9 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom
         {
             AddOptionMapping(DeviceType.Disk, CodeGenerationSupporter.Disk);
             AddOptionMapping(DeviceType.Tape, CodeGenerationSupporter.Tape);
-            AddOptionMapping(DeviceType.VirtualDevice, CodeGenerationSupporter.VirtualDevice);
-            AddOptionMapping(DeviceType.DatabaseSnapshot, CodeGenerationSupporter.DatabaseSnapshot);
+            AddOptionMapping(DeviceType.VirtualDevice, CodeGenerationSupporter.VirtualDevice, SqlVersionFlags.TSql90AndAbove);
+            AddOptionMapping(DeviceType.DatabaseSnapshot, CodeGenerationSupporter.DatabaseSnapshot, SqlVersionFlags.TSql90AndAbove);
+            AddOptionMapping(DeviceType.Url, CodeGenerationSupporter.Url, SqlVersionFlags.TSql110AndAbove);
         }
 
         internal static readonly DeviceTypesHelper Instance = new DeviceTypesHelper();

--- a/SqlScriptDom/Parser/TSql/TSql100.g
+++ b/SqlScriptDom/Parser/TSql/TSql100.g
@@ -3149,11 +3149,7 @@ deviceInfo returns [DeviceInfo vResult = FragmentFactory.CreateFragment<DeviceIn
         (
             tDevType:Identifier 
             {
-                vResult.DeviceType = DeviceTypesHelper.Instance.ParseOption(tDevType);                
-            }
-        |   Disk
-            {
-                vResult.DeviceType = DeviceType.Disk;
+                vResult.DeviceType = DeviceTypesHelper.Instance.ParseOption(tDevType, SqlVersionFlags.TSql100);
             }
         )
         EqualsSign vPhysicalDevice = stringOrVariable

--- a/SqlScriptDom/Parser/TSql/TSql110.g
+++ b/SqlScriptDom/Parser/TSql/TSql110.g
@@ -3855,11 +3855,7 @@ deviceInfo returns [DeviceInfo vResult = FragmentFactory.CreateFragment<DeviceIn
         (
             tDevType:Identifier 
             {
-                vResult.DeviceType = DeviceTypesHelper.Instance.ParseOption(tDevType);                
-            }
-        |   Disk
-            {
-                vResult.DeviceType = DeviceType.Disk;
+                vResult.DeviceType = DeviceTypesHelper.Instance.ParseOption(tDevType, SqlVersionFlags.TSql110);
             }
         )
         EqualsSign vPhysicalDevice = stringOrVariable

--- a/SqlScriptDom/Parser/TSql/TSql120.g
+++ b/SqlScriptDom/Parser/TSql/TSql120.g
@@ -3965,11 +3965,7 @@ deviceInfo returns [DeviceInfo vResult = FragmentFactory.CreateFragment<DeviceIn
         (
             tDevType:Identifier 
             {
-                vResult.DeviceType = DeviceTypesHelper.Instance.ParseOption(tDevType);                
-            }
-        |   Disk
-            {
-                vResult.DeviceType = DeviceType.Disk;
+                vResult.DeviceType = DeviceTypesHelper.Instance.ParseOption(tDevType, SqlVersionFlags.TSql120);
             }
         )
         EqualsSign vPhysicalDevice = stringOrVariable

--- a/SqlScriptDom/Parser/TSql/TSql130.g
+++ b/SqlScriptDom/Parser/TSql/TSql130.g
@@ -4833,11 +4833,7 @@ deviceInfo returns [DeviceInfo vResult = FragmentFactory.CreateFragment<DeviceIn
         (
             tDevType:Identifier
             {
-                vResult.DeviceType = DeviceTypesHelper.Instance.ParseOption(tDevType);
-            }
-        |   Disk
-            {
-                vResult.DeviceType = DeviceType.Disk;
+                vResult.DeviceType = DeviceTypesHelper.Instance.ParseOption(tDevType, SqlVersionFlags.TSql130);
             }
         )
         EqualsSign vPhysicalDevice = stringOrVariable

--- a/SqlScriptDom/Parser/TSql/TSql140.g
+++ b/SqlScriptDom/Parser/TSql/TSql140.g
@@ -5189,11 +5189,7 @@ deviceInfo returns [DeviceInfo vResult = FragmentFactory.CreateFragment<DeviceIn
         (
             tDevType:Identifier
             {
-                vResult.DeviceType = DeviceTypesHelper.Instance.ParseOption(tDevType);
-            }
-        |   Disk
-            {
-                vResult.DeviceType = DeviceType.Disk;
+                vResult.DeviceType = DeviceTypesHelper.Instance.ParseOption(tDevType, SqlVersionFlags.TSql140);
             }
         )
         EqualsSign vPhysicalDevice = stringOrVariable

--- a/SqlScriptDom/Parser/TSql/TSql150.g
+++ b/SqlScriptDom/Parser/TSql/TSql150.g
@@ -5712,11 +5712,7 @@ deviceInfo returns [DeviceInfo vResult = FragmentFactory.CreateFragment<DeviceIn
         (
             tDevType:Identifier
             {
-                vResult.DeviceType = DeviceTypesHelper.Instance.ParseOption(tDevType);
-            }
-        |   Disk
-            {
-                vResult.DeviceType = DeviceType.Disk;
+                vResult.DeviceType = DeviceTypesHelper.Instance.ParseOption(tDevType, SqlVersionFlags.TSql150);
             }
         )
         EqualsSign vPhysicalDevice = stringOrVariable

--- a/SqlScriptDom/Parser/TSql/TSql160.g
+++ b/SqlScriptDom/Parser/TSql/TSql160.g
@@ -5737,11 +5737,7 @@ deviceInfo returns [DeviceInfo vResult = FragmentFactory.CreateFragment<DeviceIn
         (
             tDevType:Identifier
             {
-                vResult.DeviceType = DeviceTypesHelper.Instance.ParseOption(tDevType);
-            }
-        |   Disk
-            {
-                vResult.DeviceType = DeviceType.Disk;
+                vResult.DeviceType = DeviceTypesHelper.Instance.ParseOption(tDevType, SqlVersionFlags.TSql160);
             }
         )
         EqualsSign vPhysicalDevice = stringOrVariable

--- a/SqlScriptDom/Parser/TSql/TSql80.g
+++ b/SqlScriptDom/Parser/TSql/TSql80.g
@@ -1259,7 +1259,7 @@ deviceInfo returns [DeviceInfo vResult = FragmentFactory.CreateFragment<DeviceIn
         (
             tDevType:Identifier 
             {
-                vResult.DeviceType = DeviceTypesHelper.Instance.ParseOption(tDevType);                
+                vResult.DeviceType = DeviceTypesHelper.Instance.ParseOption(tDevType, SqlVersionFlags.TSql80);
             }
         |   Disk
             {

--- a/SqlScriptDom/Parser/TSql/TSql90.g
+++ b/SqlScriptDom/Parser/TSql/TSql90.g
@@ -2122,11 +2122,7 @@ deviceInfo returns [DeviceInfo vResult = FragmentFactory.CreateFragment<DeviceIn
         (
             tDevType:Identifier 
             {
-                vResult.DeviceType = DeviceTypesHelper.Instance.ParseOption(tDevType);                
-            }
-        |   Disk
-            {
-                vResult.DeviceType = DeviceType.Disk;
+                vResult.DeviceType = DeviceTypesHelper.Instance.ParseOption(tDevType, SqlVersionFlags.TSql90);
             }
         )
         EqualsSign vPhysicalDevice = stringOrVariable

--- a/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGeneratorVisitor.DeviceInfo.cs
+++ b/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGeneratorVisitor.DeviceInfo.cs
@@ -17,6 +17,7 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom.ScriptGenerator
             {DeviceType.Disk,  new KeywordGenerator(TSqlTokenType.Disk)},
             {DeviceType.Tape, new IdentifierGenerator(CodeGenerationSupporter.Tape)},
             {DeviceType.VirtualDevice, new IdentifierGenerator(CodeGenerationSupporter.VirtualDevice)},
+            {DeviceType.Url, new IdentifierGenerator(CodeGenerationSupporter.Url)},
         };
 
         public override void ExplicitVisit(DeviceInfo node)

--- a/Test/SqlDom/BackupRestoreRegressionTests.cs
+++ b/Test/SqlDom/BackupRestoreRegressionTests.cs
@@ -1,15 +1,19 @@
-﻿using System.Collections.Generic;
+﻿//------------------------------------------------------------------------------
+// <copyright file="BackupRestoreRegressionTests.cs" company="Microsoft">
+//   Copyright (c) Microsoft Corporation.  All rights reserved.
+// </copyright>
+//------------------------------------------------------------------------------
+
 using Microsoft.SqlServer.TransactSql.ScriptDom;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SqlStudio.Tests.AssemblyTools.TestCategory;
+using System.Collections.Generic;
+using System.IO;
 
 namespace SqlStudio.Tests.UTSqlScriptDom
 {
-    using System;
-    using System.IO;
-
     public partial class SqlDomTests
-	{
+    {
         /// <summary>
         /// Test for RESTORE ... FROM URL ... syntax
         /// Also tests the related BACKUP ... TO URL ... syntax
@@ -152,5 +156,5 @@ RESTORE DATABASE MyDB FROM VIRTUAL_DEVICE='{A9FD7855-A978-4931-8027-F0EFB1D4F4EA
                 }
             }, true);
         }
-	}
+    }
 }

--- a/Test/SqlDom/BackupRestoreRegressionTests.cs
+++ b/Test/SqlDom/BackupRestoreRegressionTests.cs
@@ -1,0 +1,156 @@
+﻿using System.Collections.Generic;
+using Microsoft.SqlServer.TransactSql.ScriptDom;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlStudio.Tests.AssemblyTools.TestCategory;
+
+namespace SqlStudio.Tests.UTSqlScriptDom
+{
+    using System;
+    using System.IO;
+
+    public partial class SqlDomTests
+	{
+        /// <summary>
+        /// Test for RESTORE ... FROM URL ... syntax
+        /// Also tests the related BACKUP ... TO URL ... syntax
+        /// See https://github.com/microsoft/SqlScriptDOM/issues/29 for details on the issue.
+        /// </summary>
+        [TestMethod]
+        [Priority(0)]
+        [SqlStudioTestCategory(Category.UnitTest)]
+        public void BackupRestoreUrl()
+        {
+            ParserTestUtils.ExecuteTestForAllParsers(parser =>
+            {
+                string script = @"BACKUP DATABASE AdventureWorks2016
+TO URL = 'https://mystorageaccount.blob.core.windows.net/mycontainername/AdventureWorks2016.bak'
+WITH COMPRESSION
+,STATS = 5;
+
+RESTORE DATABASE Sales
+FROM URL = 'https://mystorageaccount.blob.core.windows.net/mysecondcontainer/Sales.bak'
+WITH MOVE 'Sales_Data1' to 'https://mystorageaccount.blob.core.windows.net/myfirstcontainer/Sales_Data1.mdf',
+MOVE 'Sales_log' to 'https://mystorageaccount.blob.core.windows.net/myfirstcontainer/Sales_log.ldf',
+STATS = 10;
+
+RESTORE DATABASE AdventureWorks2012
+    FROM DISK = 'Z:\SQLServerBackups\AdventureWorks2012.bak'
+    WITH FILE = 6,
+      NORECOVERY;
+";
+                using (var scriptReader = new StringReader(script))
+                {
+                    var fragment = parser.Parse(scriptReader, out IList<ParseError> errors) as TSqlScript;
+                    if (!(parser is TSql80Parser || parser is TSql90Parser || parser is TSql100Parser))
+                    {
+                        // for these parser versions we expect success
+                        Assert.AreEqual(0, errors.Count);
+                        Assert.IsTrue(fragment is TSqlScript);
+                        Assert.IsTrue(fragment.Batches[0].Statements[0] is BackupStatement);
+                        Assert.AreEqual(DeviceType.Url, (fragment.Batches[0].Statements[0] as BackupStatement).Devices[0].DeviceType);
+                        Assert.AreEqual("https://mystorageaccount.blob.core.windows.net/mycontainername/AdventureWorks2016.bak", ((fragment.Batches[0].Statements[0] as BackupStatement).Devices[0].PhysicalDevice as StringLiteral).Value);
+                        Assert.IsTrue(fragment.Batches[0].Statements[1] is RestoreStatement);
+                        Assert.AreEqual(DeviceType.Url, (fragment.Batches[0].Statements[1] as RestoreStatement).Devices[0].DeviceType);
+                        Assert.AreEqual("https://mystorageaccount.blob.core.windows.net/mysecondcontainer/Sales.bak", ((fragment.Batches[0].Statements[1] as RestoreStatement).Devices[0].PhysicalDevice as StringLiteral).Value);
+
+                        // regression test to ensure that DISK device type is correctly handled
+                        Assert.IsTrue(fragment.Batches[0].Statements[2] is RestoreStatement);
+                        Assert.AreEqual(DeviceType.Disk, (fragment.Batches[0].Statements[2] as RestoreStatement).Devices[0].DeviceType);
+                        Assert.AreEqual("Z:\\SQLServerBackups\\AdventureWorks2012.bak", ((fragment.Batches[0].Statements[2] as RestoreStatement).Devices[0].PhysicalDevice as StringLiteral).Value);
+                        Assert.AreEqual(RestoreOptionKind.File, ((fragment.Batches[0].Statements[2] as RestoreStatement).Options[0] as ScalarExpressionRestoreOption).OptionKind);
+                        Assert.AreEqual("6", (((fragment.Batches[0].Statements[2] as RestoreStatement).Options[0] as ScalarExpressionRestoreOption).Value as IntegerLiteral).Value);
+                        Assert.AreEqual("Z:\\SQLServerBackups\\AdventureWorks2012.bak", ((fragment.Batches[0].Statements[2] as RestoreStatement).Devices[0].PhysicalDevice as StringLiteral).Value);
+
+                        if (parser is TSql110Parser)
+                        {
+                            SqlScriptGenerator scriptGen = ParserTestUtils.CreateScriptGen(SqlVersion.Sql110);
+                            scriptGen.GenerateScript(fragment, out string prettyPrinted);
+                            Assert.AreEqual(@"BACKUP DATABASE AdventureWorks2016
+    TO URL = 'https://mystorageaccount.blob.core.windows.net/mycontainername/AdventureWorks2016.bak'
+    WITH COMPRESSION, STATS = 5;
+
+RESTORE DATABASE Sales FROM URL = 'https://mystorageaccount.blob.core.windows.net/mysecondcontainer/Sales.bak'
+    WITH MOVE 'Sales_Data1' TO 'https://mystorageaccount.blob.core.windows.net/myfirstcontainer/Sales_Data1.mdf', MOVE 'Sales_log' TO 'https://mystorageaccount.blob.core.windows.net/myfirstcontainer/Sales_log.ldf', STATS = 10;
+
+RESTORE DATABASE AdventureWorks2012 FROM DISK = 'Z:\SQLServerBackups\AdventureWorks2012.bak'
+    WITH FILE = 6, NORECOVERY;"
+, prettyPrinted.Trim());
+                        }
+                    }
+                    else
+                    {
+                        // for the older parsers this syntax is expected to return errors
+                        Assert.AreEqual(2, errors.Count);
+                        Assert.AreEqual("Incorrect syntax near URL.", errors[0].Message);
+                        Assert.AreEqual("Incorrect syntax near URL.", errors[1].Message);
+                    }
+                }
+            }, true);
+        }
+
+        /// <summary>
+        /// Test for RESTORE ... FROM DATABASE_SNAPSHOT ... syntax. This is supported in SQL Server 2005+, so parser version 90+.
+        /// </summary>
+        [TestMethod]
+        [Priority(0)]
+        [SqlStudioTestCategory(Category.UnitTest)]
+        public void RestoreFromDBSnapshot()
+        {
+            ParserTestUtils.ExecuteTestForAllParsers(parser =>
+            {
+                string script = @"RESTORE DATABASE AdventureWorks2012 FROM DATABASE_SNAPSHOT = 'AdventureWorks_dbss1800'";
+                using (var scriptReader = new StringReader(script))
+                {
+                    var fragment = parser.Parse(scriptReader, out IList<ParseError> errors) as TSqlScript;
+                    if (parser is TSql80Parser)
+                    {
+                        // for the older parsers this syntax is expected to return errors
+                        Assert.AreEqual(1, errors.Count);
+                        Assert.AreEqual("Incorrect syntax near DATABASE_SNAPSHOT.", errors[0].Message);
+                    }
+                    else
+                    {
+                        // for these parser versions we expect success
+                        Assert.AreEqual(0, errors.Count);
+                        Assert.IsTrue(fragment is TSqlScript);
+                        Assert.IsTrue(fragment.Batches[0].Statements[0] is RestoreStatement);
+                    }
+                }
+            }, true);
+        }
+
+        /// <summary>
+        /// Test for BACKUP / RESTORE ... VIRTUAL_DEVICE ... syntax. This is supported in SQL Server 2005+, so parser version 90+.
+        /// </summary>
+        [TestMethod]
+        [Priority(0)]
+        [SqlStudioTestCategory(Category.UnitTest)]
+        public void BackupRestoreVirtualDevice()
+        {
+            ParserTestUtils.ExecuteTestForAllParsers(parser =>
+            {
+                string script = @"BACKUP DATABASE MyDB TO VIRTUAL_DEVICE='{A9FD7855-A978-4931-8027-F0EFB1D4F4EA}' WITH STATS = 10;
+RESTORE DATABASE MyDB FROM VIRTUAL_DEVICE='{A9FD7855-A978-4931-8027-F0EFB1D4F4EA}' WITH NORECOVERY, CHECKSUM, REPLACE, BUFFERCOUNT=16, MAXTRANSFERSIZE=2097152";
+                using (var scriptReader = new StringReader(script))
+                {
+                    var fragment = parser.Parse(scriptReader, out IList<ParseError> errors) as TSqlScript;
+                    if (parser is TSql80Parser)
+                    {
+                        // for the older parsers this syntax is expected to return errors
+                        Assert.AreEqual(2, errors.Count);
+                        Assert.AreEqual("Incorrect syntax near VIRTUAL_DEVICE.", errors[0].Message);
+                        Assert.AreEqual("Incorrect syntax near VIRTUAL_DEVICE.", errors[1].Message);
+                    }
+                    else
+                    {
+                        // for these parser versions we expect success
+                        Assert.AreEqual(0, errors.Count);
+                        Assert.IsTrue(fragment is TSqlScript);
+                        Assert.IsTrue(fragment.Batches[0].Statements[0] is BackupStatement);
+                        Assert.IsTrue(fragment.Batches[0].Statements[1] is RestoreStatement);
+                    }
+                }
+            }, true);
+        }
+	}
+}


### PR DESCRIPTION
Originally created just to fix #29, but in the process fixed subtle issues with VirtualDevice and DatabaseSnapshot device types as well.

* Add the URL device type for use with BACKUP and RESTORE statements for 110 parser and above. URL backups were introduced with SQL Server 2012. Also updated the ScriptGenerator to ensure URL devices are correctly scripted.

* Add version constraints for device types DatabaseSnapshot and VirtualDevice, both of which are only supported for SQL 2005+.

* Remove dead code related to Disk device type in grammar 90 and above. In all grammars other than 80, the different device types are handled by the DeviceTypesHelper class, so the special case in the grammar for Disk device type was never used. In 80 grammar though, the Disk device type is not treated as an indentifier and hence the special case for Disk is still needed.

* Add regression tests for device types URL, VIRTUAL_DEVICE and DATABASE_SNAPSHOT, and for good measure, DISK as well