### PR TITLE
Support graph pseudo columns in relevant syntax

### DIFF
--- a/SqlScriptDom/Parser/TSql/PseudoColumnHelper.cs
+++ b/SqlScriptDom/Parser/TSql/PseudoColumnHelper.cs
@@ -23,5 +23,15 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom
         }
 
         internal static readonly PseudoColumnHelper Instance = new PseudoColumnHelper();
+
+        internal static bool IsGraphPseudoColumn(ColumnReferenceExpression col)
+        {
+            if (col.ColumnType == ColumnType.PseudoColumnGraphNodeId || col.ColumnType == ColumnType.PseudoColumnGraphEdgeId || col.ColumnType == ColumnType.PseudoColumnGraphFromId || col.ColumnType == ColumnType.PseudoColumnGraphToId)
+            {
+                return true;
+            }
+
+            return false;
+        }
     }
 }

--- a/SqlScriptDom/Parser/TSql/TSql140.g
+++ b/SqlScriptDom/Parser/TSql/TSql140.g
@@ -16154,10 +16154,10 @@ createColumnStoreIndexStatement [IToken tUnique, bool? isClustered] returns [Cre
                 {
 					foreach (var col in vResult.OrderedColumns)
 					{
-						if (col.ColumnType == ColumnType.PseudoColumnGraphNodeId || col.ColumnType == ColumnType.PseudoColumnGraphEdgeId || col.ColumnType == ColumnType.PseudoColumnGraphFromId || col.ColumnType == ColumnType.PseudoColumnGraphToId)
+						if (PseudoColumnHelper.IsGraphPseudoColumn(col))
 						{
-							ThrowIncorrectSyntaxErrorException(col);
-						}
+                            ThrowIncorrectSyntaxErrorException(col);
+                        }
 					}
                 }
             )

--- a/SqlScriptDom/Parser/TSql/TSql140.g
+++ b/SqlScriptDom/Parser/TSql/TSql140.g
@@ -16151,6 +16151,15 @@ createColumnStoreIndexStatement [IToken tUnique, bool? isClustered] returns [Cre
             tOrder:Order
             (
                 identifierColumnList[vResult, vResult.OrderedColumns]
+                {
+					foreach (var col in vResult.OrderedColumns)
+					{
+						if (col.ColumnType == ColumnType.PseudoColumnGraphNodeId || col.ColumnType == ColumnType.PseudoColumnGraphEdgeId || col.ColumnType == ColumnType.PseudoColumnGraphFromId || col.ColumnType == ColumnType.PseudoColumnGraphToId)
+						{
+							ThrowIncorrectSyntaxErrorException(col);
+						}
+					}
+                }
             )
         )?
     {
@@ -18074,16 +18083,30 @@ columnListWithParenthesis [TSqlFragment vParent, IList<ColumnReferenceExpression
 
 identifierColumnList [TSqlFragment vParent, IList<ColumnReferenceExpression> columns]
 {
-    ColumnReferenceExpression vColumn;
+    ColumnReferenceExpression vColumn = FragmentFactory.CreateFragment<ColumnReferenceExpression>();
 }
-    : LeftParenthesis vColumn = identifierColumnReferenceExpression
+    : LeftParenthesis (vColumn = identifierColumnReferenceExpression
         {
             AddAndUpdateTokenInfo(vParent, columns, vColumn);
         }
-        (Comma vColumn = identifierColumnReferenceExpression
+        | graphPseudoColumn[vColumn]
+        {
+            AddAndUpdateTokenInfo(vParent, columns, vColumn);
+        }
+        )
+        (Comma
+        {
+            vColumn = FragmentFactory.CreateFragment<ColumnReferenceExpression>();
+        }
+        (vColumn = identifierColumnReferenceExpression
             {
                 AddAndUpdateTokenInfo(vParent, columns, vColumn);
             }
+            | graphPseudoColumn[vColumn]
+            {
+                AddAndUpdateTokenInfo(vParent, columns, vColumn);
+            }
+            )
         )*
         tRParen:RightParenthesis
         {
@@ -20044,7 +20067,7 @@ literalTableHint returns [LiteralTableHint vResult = FragmentFactory.CreateFragm
 forceSeekTableHint [bool indexHintAllowed] returns [ForceSeekTableHint vResult = FragmentFactory.CreateFragment<ForceSeekTableHint>()]
 {
     IdentifierOrValueExpression vIndexValue;
-    ColumnReferenceExpression vColumnValue;
+    ColumnReferenceExpression vColumnValue = FragmentFactory.CreateFragment<ColumnReferenceExpression>();
 }
 :   tForceSeek:Identifier
         {
@@ -20065,7 +20088,11 @@ forceSeekTableHint [bool indexHintAllowed] returns [ForceSeekTableHint vResult =
                 AddAndUpdateTokenInfo(vResult, vResult.ColumnValues, vColumnValue);
             }
             (
-                Comma vColumnValue = identifierColumnReferenceExpression
+                Comma
+                {
+                    vColumnValue = FragmentFactory.CreateFragment<ColumnReferenceExpression>();
+                }
+                vColumnValue = identifierColumnReferenceExpression
                 {
                     AddAndUpdateTokenInfo(vResult, vResult.ColumnValues, vColumnValue);
                 }

--- a/SqlScriptDom/Parser/TSql/TSql150.g
+++ b/SqlScriptDom/Parser/TSql/TSql150.g
@@ -16824,10 +16824,10 @@ createColumnStoreIndexStatement [IToken tUnique, bool? isClustered] returns [Cre
                 {
 					foreach (var col in vResult.OrderedColumns)
 					{
-						if (col.ColumnType == ColumnType.PseudoColumnGraphNodeId || col.ColumnType == ColumnType.PseudoColumnGraphEdgeId || col.ColumnType == ColumnType.PseudoColumnGraphFromId || col.ColumnType == ColumnType.PseudoColumnGraphToId)
+						if (PseudoColumnHelper.IsGraphPseudoColumn(col))
 						{
-							ThrowIncorrectSyntaxErrorException(col);
-						}
+                            ThrowIncorrectSyntaxErrorException(col);
+                        }
 					}
                 }
             )

--- a/SqlScriptDom/Parser/TSql/TSql150.g
+++ b/SqlScriptDom/Parser/TSql/TSql150.g
@@ -16821,6 +16821,15 @@ createColumnStoreIndexStatement [IToken tUnique, bool? isClustered] returns [Cre
             tOrder:Order
             (
                 identifierColumnList[vResult, vResult.OrderedColumns]
+                {
+					foreach (var col in vResult.OrderedColumns)
+					{
+						if (col.ColumnType == ColumnType.PseudoColumnGraphNodeId || col.ColumnType == ColumnType.PseudoColumnGraphEdgeId || col.ColumnType == ColumnType.PseudoColumnGraphFromId || col.ColumnType == ColumnType.PseudoColumnGraphToId)
+						{
+							ThrowIncorrectSyntaxErrorException(col);
+						}
+					}
+                }
             )
         )?
     {
@@ -18776,16 +18785,30 @@ columnListWithParenthesis [TSqlFragment vParent, IList<ColumnReferenceExpression
 
 identifierColumnList [TSqlFragment vParent, IList<ColumnReferenceExpression> columns]
 {
-    ColumnReferenceExpression vColumn;
+    ColumnReferenceExpression vColumn = FragmentFactory.CreateFragment<ColumnReferenceExpression>();
 }
-    : LeftParenthesis vColumn = identifierColumnReferenceExpression
+    : LeftParenthesis (vColumn = identifierColumnReferenceExpression
         {
             AddAndUpdateTokenInfo(vParent, columns, vColumn);
         }
-        (Comma vColumn = identifierColumnReferenceExpression
+        | graphPseudoColumn[vColumn]
+        {
+            AddAndUpdateTokenInfo(vParent, columns, vColumn);
+        }
+        )
+        (Comma
+        {
+            vColumn = FragmentFactory.CreateFragment<ColumnReferenceExpression>();
+        }
+        (vColumn = identifierColumnReferenceExpression
             {
                 AddAndUpdateTokenInfo(vParent, columns, vColumn);
             }
+        | graphPseudoColumn[vColumn]
+        {
+            AddAndUpdateTokenInfo(vParent, columns, vColumn);
+        }
+        )
         )*
         tRParen:RightParenthesis
         {
@@ -20794,7 +20817,7 @@ literalTableHint returns [LiteralTableHint vResult = FragmentFactory.CreateFragm
 forceSeekTableHint [bool indexHintAllowed] returns [ForceSeekTableHint vResult = FragmentFactory.CreateFragment<ForceSeekTableHint>()]
 {
     IdentifierOrValueExpression vIndexValue;
-    ColumnReferenceExpression vColumnValue;
+    ColumnReferenceExpression vColumnValue = FragmentFactory.CreateFragment<ColumnReferenceExpression>();
 }
 :   tForceSeek:Identifier
         {
@@ -20815,7 +20838,11 @@ forceSeekTableHint [bool indexHintAllowed] returns [ForceSeekTableHint vResult =
                 AddAndUpdateTokenInfo(vResult, vResult.ColumnValues, vColumnValue);
             }
             (
-                Comma vColumnValue = identifierColumnReferenceExpression
+                Comma
+                {
+                    vColumnValue = FragmentFactory.CreateFragment<ColumnReferenceExpression>();
+                }
+                vColumnValue = identifierColumnReferenceExpression
                 {
                     AddAndUpdateTokenInfo(vResult, vResult.ColumnValues, vColumnValue);
                 }

--- a/SqlScriptDom/Parser/TSql/TSql160.g
+++ b/SqlScriptDom/Parser/TSql/TSql160.g
@@ -16870,10 +16870,10 @@ createColumnStoreIndexStatement [IToken tUnique, bool? isClustered] returns [Cre
                 {
 					foreach (var col in vResult.OrderedColumns)
 					{
-						if (col.ColumnType == ColumnType.PseudoColumnGraphNodeId || col.ColumnType == ColumnType.PseudoColumnGraphEdgeId || col.ColumnType == ColumnType.PseudoColumnGraphFromId || col.ColumnType == ColumnType.PseudoColumnGraphToId)
+						if (PseudoColumnHelper.IsGraphPseudoColumn(col))
 						{
-							ThrowIncorrectSyntaxErrorException(col);
-						}
+                            ThrowIncorrectSyntaxErrorException(col);
+                        }
 					}
                 }
             )

--- a/SqlScriptDom/Parser/TSql/TSql160.g
+++ b/SqlScriptDom/Parser/TSql/TSql160.g
@@ -16867,6 +16867,15 @@ createColumnStoreIndexStatement [IToken tUnique, bool? isClustered] returns [Cre
             tOrder:Order
             (
                 identifierColumnList[vResult, vResult.OrderedColumns]
+                {
+					foreach (var col in vResult.OrderedColumns)
+					{
+						if (col.ColumnType == ColumnType.PseudoColumnGraphNodeId || col.ColumnType == ColumnType.PseudoColumnGraphEdgeId || col.ColumnType == ColumnType.PseudoColumnGraphFromId || col.ColumnType == ColumnType.PseudoColumnGraphToId)
+						{
+							ThrowIncorrectSyntaxErrorException(col);
+						}
+					}
+                }
             )
         )?
     {
@@ -18879,16 +18888,30 @@ columnListWithParenthesis [TSqlFragment vParent, IList<ColumnReferenceExpression
 
 identifierColumnList [TSqlFragment vParent, IList<ColumnReferenceExpression> columns]
 {
-    ColumnReferenceExpression vColumn;
+    ColumnReferenceExpression vColumn = FragmentFactory.CreateFragment<ColumnReferenceExpression>();
 }
-    : LeftParenthesis vColumn = identifierColumnReferenceExpression
+    : LeftParenthesis (vColumn = identifierColumnReferenceExpression
         {
             AddAndUpdateTokenInfo(vParent, columns, vColumn);
         }
-        (Comma vColumn = identifierColumnReferenceExpression
+        | graphPseudoColumn[vColumn]
+        {
+            AddAndUpdateTokenInfo(vParent, columns, vColumn);
+        }
+        )
+        (Comma
+        {
+            vColumn = FragmentFactory.CreateFragment<ColumnReferenceExpression>();
+        }
+        (vColumn = identifierColumnReferenceExpression
             {
                 AddAndUpdateTokenInfo(vParent, columns, vColumn);
             }
+            | graphPseudoColumn[vColumn]
+            {
+                AddAndUpdateTokenInfo(vParent, columns, vColumn);
+            }
+            )
         )*
         tRParen:RightParenthesis
         {
@@ -21011,7 +21034,7 @@ literalTableHint returns [LiteralTableHint vResult = FragmentFactory.CreateFragm
 forceSeekTableHint [bool indexHintAllowed] returns [ForceSeekTableHint vResult = FragmentFactory.CreateFragment<ForceSeekTableHint>()]
 {
     IdentifierOrValueExpression vIndexValue;
-    ColumnReferenceExpression vColumnValue;
+    ColumnReferenceExpression vColumnValue = FragmentFactory.CreateFragment<ColumnReferenceExpression>();
 }
 :   tForceSeek:Identifier
         {
@@ -21032,7 +21055,11 @@ forceSeekTableHint [bool indexHintAllowed] returns [ForceSeekTableHint vResult =
                 AddAndUpdateTokenInfo(vResult, vResult.ColumnValues, vColumnValue);
             }
             (
-                Comma vColumnValue = identifierColumnReferenceExpression
+                Comma
+                {
+                    vColumnValue = FragmentFactory.CreateFragment<ColumnReferenceExpression>();
+                }
+                vColumnValue = identifierColumnReferenceExpression
                 {
                     AddAndUpdateTokenInfo(vResult, vResult.ColumnValues, vColumnValue);
                 }

--- a/Test/SqlDom/Baselines140/GraphDbSyntaxTests140.sql
+++ b/Test/SqlDom/Baselines140/GraphDbSyntaxTests140.sql
@@ -126,6 +126,10 @@ CREATE TABLE [dbo].[node_4] (
     INDEX idx NONCLUSTERED COLUMNSTORE (c1, $NODE_ID)
 ) AS NODE;
 
+CREATE INDEX NC_node_4
+    ON node_4(c1)
+    INCLUDE($NODE_ID);
+
 CREATE TABLE [dbo].[edge_1] (
     c1 INT,
     INDEX idx NONCLUSTERED ($EDGE_ID)
@@ -151,3 +155,5 @@ CREATE TABLE [dbo].[edge_5] (
     INDEX idx NONCLUSTERED COLUMNSTORE ($FROM_ID, $TO_ID, $EDGE_ID, c1)
 ) AS EDGE;
 
+CREATE STATISTICS stat2
+    ON n1(c1, $NODE_ID, c2);

--- a/Test/SqlDom/Baselines150/GraphDbSyntaxTests150.sql
+++ b/Test/SqlDom/Baselines150/GraphDbSyntaxTests150.sql
@@ -1,3 +1,8 @@
+CREATE TABLE [dbo].[node_5] (
+    c1 INT,
+    INDEX idx (c1) INCLUDE ($NODE_ID)
+) AS NODE;
+
 ALTER TABLE edge
     ADD CONSTRAINT myConstraint CONNECTION (node3 TO node4);
 

--- a/Test/SqlDom/GraphDbRegressionTests.cs
+++ b/Test/SqlDom/GraphDbRegressionTests.cs
@@ -1,0 +1,88 @@
+﻿//------------------------------------------------------------------------------
+// <copyright file="BackupRestoreRegressionTests.cs" company="Microsoft">
+//   Copyright (c) Microsoft Corporation.  All rights reserved.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.SqlServer.TransactSql.ScriptDom;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlStudio.Tests.AssemblyTools.TestCategory;
+using System.Collections.Generic;
+using System.IO;
+
+namespace SqlStudio.Tests.UTSqlScriptDom
+{
+    public partial class SqlDomTests
+    {
+        /// <summary>
+        /// Test for graph pseudo column as included column in a CREATE INDEX statement
+        /// See https://github.com/microsoft/SqlScriptDOM/issues/25 for details on the issue.
+        /// </summary>
+        [TestMethod]
+        [Priority(0)]
+        [SqlStudioTestCategory(Category.UnitTest)]
+        public void GraphPseudoColumnsInCreateIndexIncludedColumns()
+        {
+            ParserTestUtils.ExecuteTestForParsers(parser =>
+            {
+                string script = @"create index NC_node_4	ON node_4 (c1) INCLUDE ($node_id);";
+                using (var scriptReader = new StringReader(script))
+                {
+                    var fragment = parser.Parse(scriptReader, out IList<ParseError> errors) as TSqlScript;
+                    Assert.AreEqual(0, errors.Count);
+                    Assert.IsTrue(fragment is TSqlScript);
+                    Assert.IsTrue(fragment.Batches[0].Statements[0] is CreateIndexStatement);
+                    Assert.AreEqual(ColumnType.PseudoColumnGraphNodeId, (fragment.Batches[0].Statements[0] as CreateIndexStatement).IncludeColumns[0].ColumnType);
+                    Assert.AreEqual(ColumnType.Regular, (fragment.Batches[0].Statements[0] as CreateIndexStatement).Columns[0].Column.ColumnType);
+                    Assert.AreEqual("c1", (fragment.Batches[0].Statements[0] as CreateIndexStatement).Columns[0].Column.MultiPartIdentifier.Identifiers[0].Value);
+                }
+            }, new TSql140Parser(true), new TSql150Parser(true), new TSql160Parser(true));
+        }
+
+        /// <summary>
+        /// Test for graph pseudo column as included column in an inline index definition within a CREATE TABLE statement (starting SQL 2019)
+        /// See https://github.com/microsoft/SqlScriptDOM/issues/25 for details on the issue.
+        /// </summary>
+        [TestMethod]
+        [Priority(0)]
+        [SqlStudioTestCategory(Category.UnitTest)]
+        public void GraphPseudoColumnsInInlineIndexIncludedColumns()
+        {
+            ParserTestUtils.ExecuteTestForParsers(parser =>
+            {
+                string script = @"create table [dbo].[node_5] (c1 int, index idx (c1) include ($node_id)) As Node";
+                using (var scriptReader = new StringReader(script))
+                {
+                    var fragment = parser.Parse(scriptReader, out IList<ParseError> errors) as TSqlScript;
+                    Assert.AreEqual(0, errors.Count);
+                    Assert.IsTrue(fragment is TSqlScript);
+                    Assert.IsTrue(fragment.Batches[0].Statements[0] is CreateTableStatement);
+                    Assert.AreEqual(ColumnType.PseudoColumnGraphNodeId, (fragment.Batches[0].Statements[0] as CreateTableStatement).Definition.Indexes[0].IncludeColumns[0].ColumnType);
+                    Assert.AreEqual(ColumnType.Regular, (fragment.Batches[0].Statements[0] as CreateTableStatement).Definition.Indexes[0].Columns[0].Column.ColumnType);
+                    Assert.AreEqual("c1", (fragment.Batches[0].Statements[0] as CreateTableStatement).Definition.Indexes[0].Columns[0].Column.MultiPartIdentifier.Identifiers[0].Value);
+                }
+            }, new TSql150Parser(true), new TSql160Parser(true));
+        }
+
+        /// <summary>
+        /// Currently, graph pseudo columns are not supported in the ORDER clause for a clustered columnstore index
+        /// This was added as regression test when fixing https://github.com/microsoft/SqlScriptDOM/issues/25.
+        /// </summary>
+        [TestMethod]
+        [Priority(0)]
+        [SqlStudioTestCategory(Category.UnitTest)]
+        public void DisallowGraphPseudoColumnsInOrderedClusteredColumnstore()
+        {
+            ParserTestUtils.ExecuteTestForParsers(parser =>
+            {
+                string script = @"create clustered columnstore index occi1 on n1 ORDER (c1, $node_id, c2)";
+                using (var scriptReader = new StringReader(script))
+                {
+                    var fragment = parser.Parse(scriptReader, out IList<ParseError> errors) as TSqlScript;
+                    Assert.AreEqual(1, errors.Count);
+                    Assert.AreEqual("Incorrect syntax near $node_id.", errors[0].Message);
+                }
+            }, new TSql130Parser(true), new TSql140Parser(true), new TSql150Parser(true), new TSql160Parser(true));
+        }
+    }
+}

--- a/Test/SqlDom/Only140SyntaxTests.cs
+++ b/Test/SqlDom/Only140SyntaxTests.cs
@@ -25,7 +25,7 @@ namespace SqlStudio.Tests.UTSqlScriptDom
             new ParserTest140("AlterTableAlterColumnStatementTests140.sql", 14, 14, 14, 14, 14, 12),
             new ParserTest140("BulkInsertStatementTests140.sql", 12, 12, 12, 12, 12, 12),
             new ParserTest140("OpenRowsetBulkStatementTests140.sql", 9, 9, 9, 9, 9, 9),
-            new ParserTest140("GraphDbSyntaxTests140.sql", 28, 28, 28, 28, 28, 28),
+            new ParserTest140("GraphDbSyntaxTests140.sql", nErrors80: 30, nErrors90: 30, nErrors100: 30, nErrors110: 30, nErrors120: 30, nErrors130: 30),
             new ParserTest140("AlterDatabaseScopedGenericConfigurationTests140.sql", 33, 33, 33, 33, 33, 11),
             new ParserTest140("AlterTableDropTableElementStatementTests140.sql", 1, 5, 5, 5, 5, 5),
             new ParserTest140("DropIndexStatementTests140.sql", 4, 4, 4, 4, 4, 4),

--- a/Test/SqlDom/Only150SyntaxTests.cs
+++ b/Test/SqlDom/Only150SyntaxTests.cs
@@ -23,7 +23,7 @@ namespace SqlStudio.Tests.UTSqlScriptDom
             new ParserTest150("CreateIndexStatementTests150.sql",  9, 9, 9, 9, 9, 9, 9),
             new ParserTest150("CreateTableTests150.sql", 5, 5, 5, 5, 5, 5, 5),
             new ParserTest150("ScalarUDFInlineTests150.sql", 4, 5, 5, 5, 5, 4, 4),
-            new ParserTest150("GraphDbSyntaxTests150.sql", 5, 5, 5, 5, 5, 5, 5),
+            new ParserTest150("GraphDbSyntaxTests150.sql", 6, 6, 6, 6, 6, 6, 6),
             new ParserTest150("BulkInsertStatementTests150.sql", 6, 6, 6, 6, 6, 6, 6),
             new ParserTest150("OpenRowsetBulkStatementTests150.sql", 12, 12, 12, 12, 12, 12, 12),
             /* When a batch is being parsed via a rule and the rule consumes all the tokens it can then it expects

--- a/Test/SqlDom/Only160SyntaxTests.cs
+++ b/Test/SqlDom/Only160SyntaxTests.cs
@@ -38,7 +38,7 @@ namespace SqlStudio.Tests.UTSqlScriptDom
             new ParserTest160(scriptFilename: "CreateExternalFileFormatStatementTests160.sql", nErrors80: 2, nErrors90: 2, nErrors100: 2, nErrors110: 2, nErrors120: 2, nErrors130: 1, nErrors140: 1, nErrors150: 1),
             new ParserTest160("StringConcatOperatorTests160.sql", nErrors80: 11, nErrors90: 11, nErrors100: 11, nErrors110: 11, nErrors120: 11, nErrors130: 11, nErrors140: 11, nErrors150: 11),
             new ParserTest160("InlineIndexColumnWithINCLUDEtest.sql", nErrors80: 3, nErrors90: 3, nErrors100: 3, nErrors110: 3, nErrors120: 2, nErrors130: 2, nErrors140: 2, nErrors150: 2)
-        };
+         };
 
         private static readonly ParserTest[] SqlAzure160_TestInfos = 
         {

--- a/Test/SqlDom/TestScripts/GraphDbSyntaxTests140.sql
+++ b/Test/SqlDom/TestScripts/GraphDbSyntaxTests140.sql
@@ -104,6 +104,8 @@ CREATE TABLE [dbo].[node_3] (c1 int, index idx nonclustered columnstore($node_id
 
 CREATE TABLE [dbo].[node_4] (c1 int, index idx nonclustered columnstore(c1, $node_id)) AS NODE;
 
+create index NC_node_4	ON node_4 (c1) INCLUDE ($node_id);
+
 -- Inline indexes require another column element, so inline indexes don't work on edge tables
 -- without a column.
 --
@@ -116,3 +118,5 @@ CREATE TABLE [dbo].[edge_3] (c1 int, index idx nonclustered ($to_id, $from_id, $
 CREATE TABLE [dbo].[edge_4] (c1 int, index idx nonclustered columnstore ($edge_id, c1)) AS EDGE;
 
 CREATE TABLE [dbo].[edge_5] (c1 int, index idx nonclustered columnstore ($from_id, $to_id, $edge_id, c1)) AS EDGE;
+
+create statistics stat2 on n1(c1, $node_id, c2)

--- a/Test/SqlDom/TestScripts/GraphDbSyntaxTests150.sql
+++ b/Test/SqlDom/TestScripts/GraphDbSyntaxTests150.sql
@@ -1,3 +1,5 @@
+create table [dbo].[node_5] (c1 int, index idx (c1) include ($node_id)) As Node;
+
 ALTER TABLE edge add constraint myConstraint CONNECTION (node3 TO node4);
 
 ALTER TABLE edge2


### PR DESCRIPTION
* Support graph pseudo columns in INCLUDE clause. Fixes #25.
* Support graph pseudo columns in CREATE STATISTICS statement.
* Block unsupported graph pseudo columns in ORDER clause of CCI.