### PR TITLE
Fix SqlScriptGenerator Options SqlVersion Issue

### DIFF
--- a/SqlScriptDom/ScriptDom/SqlServer/Sql100ScriptGenerator.cs
+++ b/SqlScriptDom/ScriptDom/SqlServer/Sql100ScriptGenerator.cs
@@ -28,6 +28,7 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom
         public Sql100ScriptGenerator(SqlScriptGeneratorOptions options)
             : base(options)
         {
+            options.SqlVersion = SqlVersion.Sql100;
         }
 
         internal override SqlScriptGeneratorVisitor CreateSqlScriptGeneratorVisitor(SqlScriptGeneratorOptions options, ScriptWriter scriptWriter)

--- a/SqlScriptDom/ScriptDom/SqlServer/Sql110ScriptGenerator.cs
+++ b/SqlScriptDom/ScriptDom/SqlServer/Sql110ScriptGenerator.cs
@@ -28,6 +28,7 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom
         public Sql110ScriptGenerator(SqlScriptGeneratorOptions options)
             : base(options)
         {
+            options.SqlVersion = SqlVersion.Sql110;
         }
 
         internal override SqlScriptGeneratorVisitor CreateSqlScriptGeneratorVisitor(SqlScriptGeneratorOptions options, ScriptWriter scriptWriter)

--- a/SqlScriptDom/ScriptDom/SqlServer/Sql120ScriptGenerator.cs
+++ b/SqlScriptDom/ScriptDom/SqlServer/Sql120ScriptGenerator.cs
@@ -28,6 +28,7 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom
         public Sql120ScriptGenerator(SqlScriptGeneratorOptions options)
             : base(options)
         {
+            options.SqlVersion = SqlVersion.Sql120;
         }
 
         internal override SqlScriptGeneratorVisitor CreateSqlScriptGeneratorVisitor(SqlScriptGeneratorOptions options, ScriptWriter scriptWriter)

--- a/SqlScriptDom/ScriptDom/SqlServer/Sql130ScriptGenerator.cs
+++ b/SqlScriptDom/ScriptDom/SqlServer/Sql130ScriptGenerator.cs
@@ -28,6 +28,7 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom
         public Sql130ScriptGenerator(SqlScriptGeneratorOptions options)
             : base(options)
         {
+            options.SqlVersion = SqlVersion.Sql130;
         }
 
         internal override SqlScriptGeneratorVisitor CreateSqlScriptGeneratorVisitor(SqlScriptGeneratorOptions options, ScriptWriter scriptWriter)

--- a/SqlScriptDom/ScriptDom/SqlServer/Sql140ScriptGenerator.cs
+++ b/SqlScriptDom/ScriptDom/SqlServer/Sql140ScriptGenerator.cs
@@ -28,6 +28,7 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom
         public Sql140ScriptGenerator(SqlScriptGeneratorOptions options)
             : base(options)
         {
+            options.SqlVersion = SqlVersion.Sql140;
         }
 
         internal override SqlScriptGeneratorVisitor CreateSqlScriptGeneratorVisitor(SqlScriptGeneratorOptions options, ScriptWriter scriptWriter)

--- a/SqlScriptDom/ScriptDom/SqlServer/Sql150ScriptGenerator.cs
+++ b/SqlScriptDom/ScriptDom/SqlServer/Sql150ScriptGenerator.cs
@@ -28,6 +28,7 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom
         public Sql150ScriptGenerator(SqlScriptGeneratorOptions options)
             : base(options)
         {
+            options.SqlVersion = SqlVersion.Sql150;
         }
 
         internal override SqlScriptGeneratorVisitor CreateSqlScriptGeneratorVisitor(SqlScriptGeneratorOptions options, ScriptWriter scriptWriter)

--- a/SqlScriptDom/ScriptDom/SqlServer/Sql160ScriptGenerator.cs
+++ b/SqlScriptDom/ScriptDom/SqlServer/Sql160ScriptGenerator.cs
@@ -28,6 +28,7 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom
         public Sql160ScriptGenerator(SqlScriptGeneratorOptions options)
             : base(options)
         {
+            options.SqlVersion = SqlVersion.Sql160;
         }
 
         internal override SqlScriptGeneratorVisitor CreateSqlScriptGeneratorVisitor(SqlScriptGeneratorOptions options, ScriptWriter scriptWriter)

--- a/SqlScriptDom/ScriptDom/SqlServer/Sql80ScriptGenerator.cs
+++ b/SqlScriptDom/ScriptDom/SqlServer/Sql80ScriptGenerator.cs
@@ -28,6 +28,7 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom
         public Sql80ScriptGenerator(SqlScriptGeneratorOptions options)
             : base(options)
         {
+            options.SqlVersion = SqlVersion.Sql80;
         }
 
         internal override SqlScriptGeneratorVisitor CreateSqlScriptGeneratorVisitor(SqlScriptGeneratorOptions options, ScriptWriter scriptWriter)

--- a/SqlScriptDom/ScriptDom/SqlServer/Sql90ScriptGenerator.cs
+++ b/SqlScriptDom/ScriptDom/SqlServer/Sql90ScriptGenerator.cs
@@ -28,6 +28,7 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom
         public Sql90ScriptGenerator(SqlScriptGeneratorOptions options)
             : base(options)
         {
+            options.SqlVersion = SqlVersion.Sql90;
         }
 
         internal override SqlScriptGeneratorVisitor CreateSqlScriptGeneratorVisitor(SqlScriptGeneratorOptions options, ScriptWriter scriptWriter)

--- a/SqlScriptDom/ScriptDom/SqlServer/SqlServerlessScriptGenerator.cs
+++ b/SqlScriptDom/ScriptDom/SqlServer/SqlServerlessScriptGenerator.cs
@@ -28,6 +28,7 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom
         public SqlServerlessScriptGenerator(SqlScriptGeneratorOptions options)
             : base(options)
         {
+            options.SqlVersion = SqlVersion.Sql160;
         }
 
         internal override SqlScriptGeneratorVisitor CreateSqlScriptGeneratorVisitor(SqlScriptGeneratorOptions options, ScriptWriter scriptWriter)

--- a/Test/SqlDom/ScriptGeneratorTests.cs
+++ b/Test/SqlDom/ScriptGeneratorTests.cs
@@ -1,5 +1,5 @@
 ﻿//------------------------------------------------------------------------------
-// <copyright file="TestUtilities.cs" company="Microsoft">
+// <copyright file="ScriptGeneratorTests.cs" company="Microsoft">
 //         Copyright (c) Microsoft Corporation.  All rights reserved.
 // </copyright>
 //------------------------------------------------------------------------------
@@ -11,7 +11,8 @@ using SqlStudio.Tests.AssemblyTools.TestCategory;
 namespace SqlStudio.Tests.UTSqlScriptDom
 {
     // These tests ensure that we get the correct SqlVersion for each type of SqlScriptGenerator's Options
-    public partial class SqlDomTests
+    [TestClass]
+    public class SqlScriptGeneratorTests
     {
         [TestMethod]
         [Priority(0)]

--- a/Test/SqlDom/ScriptGeneratorTests.cs
+++ b/Test/SqlDom/ScriptGeneratorTests.cs
@@ -1,0 +1,116 @@
+﻿//------------------------------------------------------------------------------
+// <copyright file="TestUtilities.cs" company="Microsoft">
+//         Copyright (c) Microsoft Corporation.  All rights reserved.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.SqlServer.TransactSql.ScriptDom;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlStudio.Tests.AssemblyTools.TestCategory;
+
+namespace SqlStudio.Tests.UTSqlScriptDom
+{
+    // These tests ensure that we get the correct SqlVersion for each type of SqlScriptGenerator's Options
+    public partial class SqlDomTests
+    {
+        [TestMethod]
+        [Priority(0)]
+        [SqlStudioTestCategory(Category.UnitTest)]
+        public void TestSql100ScriptGenerator()
+        {
+            var options = new SqlScriptGeneratorOptions();
+            var scriptGenerator = new Sql100ScriptGenerator(options);
+            Assert.AreEqual(SqlVersion.Sql100, scriptGenerator.Options.SqlVersion);
+        }
+
+        [TestMethod]
+        [Priority(0)]
+        [SqlStudioTestCategory(Category.UnitTest)]
+        public void TestSql110ScriptGenerator()
+        {
+            var options = new SqlScriptGeneratorOptions();
+            var scriptGenerator = new Sql110ScriptGenerator(options);
+            Assert.AreEqual(SqlVersion.Sql110, scriptGenerator.Options.SqlVersion);
+        }
+
+        [TestMethod]
+        [Priority(0)]
+        [SqlStudioTestCategory(Category.UnitTest)]
+        public void TestSql120ScriptGenerator()
+        {
+            var options = new SqlScriptGeneratorOptions();
+            var scriptGenerator = new Sql120ScriptGenerator(options);
+            Assert.AreEqual(SqlVersion.Sql120, scriptGenerator.Options.SqlVersion);
+        }
+
+        [TestMethod]
+        [Priority(0)]
+        [SqlStudioTestCategory(Category.UnitTest)]
+        public void TestSql130ScriptGenerator()
+        {
+            var options = new SqlScriptGeneratorOptions();
+            var scriptGenerator = new Sql130ScriptGenerator(options);
+            Assert.AreEqual(SqlVersion.Sql130, scriptGenerator.Options.SqlVersion);
+        }
+
+        [TestMethod]
+        [Priority(0)]
+        [SqlStudioTestCategory(Category.UnitTest)]
+        public void TestSql140ScriptGenerator()
+        {
+            var options = new SqlScriptGeneratorOptions();
+            var scriptGenerator = new Sql140ScriptGenerator(options);
+            Assert.AreEqual(SqlVersion.Sql140, scriptGenerator.Options.SqlVersion);
+        }
+
+        [TestMethod]
+        [Priority(0)]
+        [SqlStudioTestCategory(Category.UnitTest)]
+        public void TestSql150ScriptGenerator()
+        {
+            var options = new SqlScriptGeneratorOptions();
+            var scriptGenerator = new Sql150ScriptGenerator(options);
+            Assert.AreEqual(SqlVersion.Sql150, scriptGenerator.Options.SqlVersion);
+        }
+
+        [TestMethod]
+        [Priority(0)]
+        [SqlStudioTestCategory(Category.UnitTest)]
+        public void TestSql160ScriptGenerator()
+        {
+            var options = new SqlScriptGeneratorOptions();
+            var scriptGenerator = new Sql160ScriptGenerator(options);
+            Assert.AreEqual(SqlVersion.Sql160, scriptGenerator.Options.SqlVersion);
+        }
+
+        [TestMethod]
+        [Priority(0)]
+        [SqlStudioTestCategory(Category.UnitTest)]
+        public void TestSql80ScriptGenerator()
+        {
+            var options = new SqlScriptGeneratorOptions();
+            var scriptGenerator = new Sql80ScriptGenerator(options);
+            Assert.AreEqual(SqlVersion.Sql80, scriptGenerator.Options.SqlVersion);
+        }
+
+        [TestMethod]
+        [Priority(0)]
+        [SqlStudioTestCategory(Category.UnitTest)]
+        public void TestSql90ScriptGenerator()
+        {
+            var options = new SqlScriptGeneratorOptions();
+            var scriptGenerator = new Sql90ScriptGenerator(options);
+            Assert.AreEqual(SqlVersion.Sql90, scriptGenerator.Options.SqlVersion);
+        }
+
+        [TestMethod]
+        [Priority(0)]
+        [SqlStudioTestCategory(Category.UnitTest)]
+        public void TestSqlServerlessScriptGenerator()
+        {
+            var options = new SqlScriptGeneratorOptions();
+            var scriptGenerator = new SqlServerlessScriptGenerator(options);
+            Assert.AreEqual(SqlVersion.Sql160, scriptGenerator.Options.SqlVersion);
+        }
+    }
+}


### PR DESCRIPTION
Added the SqlVersion to options for each type of SqlScriptGenerator. Also added the test case to check if they are assigned properly. 

Adding a screenshot to show the fixed status.

![Screenshot 2024-01-25 224420](https://github.com/microsoft/SqlScriptDOM/assets/30655124/ee7bf3a5-5820-4a1a-b202-572fbe4e5716)
