### PR TITLE
add formatting options to allow keywords to be at the end of the line

### DIFF
--- a/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGeneratorVisitor.BooleanBinaryExpression.cs
+++ b/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGeneratorVisitor.BooleanBinaryExpression.cs
@@ -19,11 +19,13 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom.ScriptGenerator
 
             Boolean insertNewline = RightPredicateOnNewline(node);
 
-            GenerateNewLineOrSpace(insertNewline);
+            GenerateNewLineOrSpace(insertNewline && _options.NewLineBeforeBinaryBooleanExpresson);
 
             GenerateBinaryOperator(node.BinaryExpressionType);
 
-            GenerateSpaceAndFragmentIfNotNull(node.SecondExpression);
+            GenerateNewLineOrSpace(insertNewline && _options.NewLineAfterBinaryBooleanExpresson);
+
+            GenerateFragmentIfNotNull(node.SecondExpression);
 
             PopAlignmentPoint();
         }

--- a/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGeneratorVisitor.FromClause.cs
+++ b/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGeneratorVisitor.FromClause.cs
@@ -31,8 +31,12 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom.ScriptGenerator
 
                     MarkClauseBodyAlignmentWhenNecessary(_options.NewLineBeforeFromClause, clauseBody);
 
-                    GenerateSpace();
-
+                    GenerateNewLineOrSpace(_options.NewLineAfterFromClause);
+                    if (_options.NewLineAfterFromClause)
+                    {
+                        Indent();
+                    }
+                    
                     AlignmentPoint fromItems = new AlignmentPoint();
                     MarkAndPushAlignmentPoint(fromItems);
 

--- a/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGeneratorVisitor.GroupByClause.cs
+++ b/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGeneratorVisitor.GroupByClause.cs
@@ -16,6 +16,11 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom.ScriptGenerator
             GenerateKeyword(TSqlTokenType.Group);
             GenerateSpaceAndKeyword(TSqlTokenType.By);
 
+            if (_options.NewLineAfterGroupByKeyword)
+            {
+                NewLineAndIndent();
+            }
+
             if (node.All)
             {
                 GenerateSpaceAndKeyword(TSqlTokenType.All);

--- a/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGeneratorVisitor.HavingClause.cs
+++ b/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGeneratorVisitor.HavingClause.cs
@@ -16,6 +16,11 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom.ScriptGenerator
 
             GenerateKeyword(TSqlTokenType.Having);
 
+            if (_options.NewLineAfterHavingKeyword)
+            {
+                NewLineAndIndent();
+            }
+
             AlignmentPoint clauseBody = GetAlignmentPointForFragment(node, ClauseBody);
             MarkClauseBodyAlignmentWhenNecessary(_options.NewLineBeforeHavingClause, clauseBody);
 

--- a/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGeneratorVisitor.OrderByClause.cs
+++ b/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGeneratorVisitor.OrderByClause.cs
@@ -17,6 +17,11 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom.ScriptGenerator
             GenerateKeyword(TSqlTokenType.Order);
             GenerateSpaceAndKeyword(TSqlTokenType.By);
 
+            if (_options.NewLineAfterHavingKeyword)
+            {
+                NewLineAndIndent();
+            }
+
             AlignmentPoint clauseBody = GetAlignmentPointForFragment(node, ClauseBody);
             MarkClauseBodyAlignmentWhenNecessary(_options.NewLineBeforeOrderByClause, clauseBody);
 

--- a/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGeneratorVisitor.OrderByClause.cs
+++ b/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGeneratorVisitor.OrderByClause.cs
@@ -17,7 +17,7 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom.ScriptGenerator
             GenerateKeyword(TSqlTokenType.Order);
             GenerateSpaceAndKeyword(TSqlTokenType.By);
 
-            if (_options.NewLineAfterHavingKeyword)
+            if (_options.NewLineAfterOrderByKeyword)
             {
                 NewLineAndIndent();
             }

--- a/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGeneratorVisitor.QualifiedJoin.cs
+++ b/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGeneratorVisitor.QualifiedJoin.cs
@@ -51,8 +51,20 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom.ScriptGenerator
             NewLine();
             GenerateFragmentIfNotNull(node.SecondTableReference);
 
-            NewLine();
-            GenerateKeyword(TSqlTokenType.On); 
+            if (_options.NewLineBeforeOnKeyword)
+            {
+                NewLine();
+            }
+            else
+            {
+                GenerateSpace();
+            }
+            GenerateKeyword(TSqlTokenType.On);
+            if (_options.NewLineAfterOnKeyword)
+            {
+                NewLine();
+                Indent();
+            }
 
             GenerateSpaceAndFragmentIfNotNull(node.SearchCondition);
         }

--- a/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGeneratorVisitor.QuerySpecification.cs
+++ b/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGeneratorVisitor.QuerySpecification.cs
@@ -33,7 +33,15 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom.ScriptGenerator
 
             GenerateSpaceAndFragmentIfNotNull(node.TopRowFilter);
 
-            GenerateSpace();
+            if (_options.NewLineAfterSelectKeyword)
+            {
+                NewLineAndIndent();
+            }
+            else
+            {
+                GenerateSpace();
+            }
+
             GenerateSelectElementsList(node.SelectElements);
 
             if (intoClause != null)

--- a/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGeneratorVisitor.WhereClause.cs
+++ b/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGeneratorVisitor.WhereClause.cs
@@ -16,6 +16,11 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom.ScriptGenerator
 
             GenerateKeyword(TSqlTokenType.Where);
 
+            if (_options.NewLineAfterWhereKeyword)
+            {
+                NewLineAndIndent();
+            }
+
             AlignmentPoint clauseBody = GetAlignmentPointForFragment(node, ClauseBody);
 
             MarkClauseBodyAlignmentWhenNecessary(_options.NewLineBeforeWhereClause, clauseBody);

--- a/SqlScriptDom/ScriptDom/SqlServer/Settings/SqlScriptGeneratorOptions.xml
+++ b/SqlScriptDom/ScriptDom/SqlServer/Settings/SqlScriptGeneratorOptions.xml
@@ -38,33 +38,33 @@
     <Setting name="NewLineBeforeFromClause" type="bool" default="true">
       <Summary>Gets or sets a boolean indicating if there should be a newline before the FROM clause in a SELECT statement</Summary>
     </Setting>
-	<Setting name="NewLineAfterFromClause" type="bool" default="false">
-	  <Summary>Gets or sets a boolean indicating if there should be a newline after the FROM clause in a SELECT statement</Summary>
-	</Setting>
-	<Setting name="NewLineAfterSelectKeyword" type="bool" default="false">
-	  <Summary>Gets or sets a boolean indicating if there should be a newline after the SELECT in a SELECT statement</Summary>
-	</Setting>
-	 <Setting name="NewLineAfterWhereKeyword" type="bool" default="false">
-	  <Summary>Gets or sets a boolean indicating if there should be a newline after the WHERE keyword in a WHERE clause</Summary>
-	 </Setting>
+    <Setting name="NewLineAfterFromClause" type="bool" default="false">
+  	  <Summary>Gets or sets a boolean indicating if there should be a newline after the FROM clause in a SELECT statement</Summary>
+  	</Setting>
+  	<Setting name="NewLineAfterSelectKeyword" type="bool" default="false">
+  	  <Summary>Gets or sets a boolean indicating if there should be a newline after the SELECT in a SELECT statement</Summary>
+  	</Setting>
+  	<Setting name="NewLineAfterWhereKeyword" type="bool" default="false">
+  	  <Summary>Gets or sets a boolean indicating if there should be a newline after the WHERE keyword in a WHERE clause</Summary>
+  	</Setting>
     <Setting name="NewLineBeforeWhereClause" type="bool" default="true">
       <Summary>Gets or sets a boolean indicating if there should be a newline before the WHERE clause in a SELECT statement</Summary>
     </Setting>
-	<Setting name="NewLineAfterGroupByKeyword" type="bool" default="false">
-	 <Summary>Gets or sets a boolean indicating if there should be a newline after the GROUP BY keyword in a GROUP BY clause</Summary>
-	</Setting>
+  	<Setting name="NewLineAfterGroupByKeyword" type="bool" default="false">
+  	  <Summary>Gets or sets a boolean indicating if there should be a newline after the GROUP BY keyword in a GROUP BY clause</Summary>
+  	</Setting>
     <Setting name="NewLineBeforeGroupByClause" type="bool" default="true">
       <Summary>Gets or sets a boolean indicating if there should be a newline before the GROUP BY clause in a SELECT statement</Summary>
     </Setting>
-	<Setting name="NewLineAfterOrderByKeyword" type="bool" default="false">
-	  <Summary>Gets or sets a boolean indicating if there should be a newline after the ORDER BY keyword in a GROUP BY clause</Summary>
-	</Setting>
+  	<Setting name="NewLineAfterOrderByKeyword" type="bool" default="false">
+  	  <Summary>Gets or sets a boolean indicating if there should be a newline after the ORDER BY keyword in a GROUP BY clause</Summary>
+  	</Setting>
     <Setting name="NewLineBeforeOrderByClause" type="bool" default="true">
       <Summary>Gets or sets a boolean indicating if there should be a newline before the ORDER BY clause in a SELECT statement</Summary>
     </Setting>
-	<Setting name="NewLineAfterHavingKeyword" type="bool" default="false">
-	  <Summary>Gets or sets a boolean indicating if there should be a newline after the HAVING keyword in a GROUP BY clause</Summary>
-	</Setting>
+  	<Setting name="NewLineAfterHavingKeyword" type="bool" default="false">
+  	  <Summary>Gets or sets a boolean indicating if there should be a newline after the HAVING keyword in a GROUP BY clause</Summary>
+  	</Setting>
     <Setting name="NewLineBeforeHavingClause" type="bool" default="true">
       <Summary>Gets or sets a boolean indicating if there should be a newline before the HAVING clause in a SELECT statement</Summary>
     </Setting>
@@ -74,24 +74,24 @@
     <Setting name="NewLineBeforeJoinClause" type="bool" default="true">
       <Summary>Gets or sets a boolean indicating if there should be a newline before the JOIN clause in a SELECT statement</Summary>
     </Setting>
-	<Setting name="NewLineBeforeOnKeyword" type="bool" default="true">
-	  <Summary>Gets or sets a boolean indicating if there should be a newline before the ON keyword in a JOIN clause</Summary>
-	</Setting>
-	<Setting name="NewLineAfterOnKeyword" type="bool" default="false">
-	  <Summary>Gets or sets a boolean indicating if there should be a newline after the ON keyword in a JOIN clause</Summary>
-	</Setting>
+  	<Setting name="NewLineBeforeOnKeyword" type="bool" default="true">
+  	  <Summary>Gets or sets a boolean indicating if there should be a newline before the ON keyword in a JOIN clause</Summary>
+  	</Setting>
+  	<Setting name="NewLineAfterOnKeyword" type="bool" default="false">
+  	  <Summary>Gets or sets a boolean indicating if there should be a newline after the ON keyword in a JOIN clause</Summary>
+  	</Setting>
     <Setting name="NewLineBeforeOffsetClause" type="bool" default="true">
       <Summary>Gets or sets a boolean indicating if there should be a newline before the OFFSET clause</Summary>
     </Setting>
     <Setting name="NewLineBeforeOutputClause" type="bool" default="true">
       <Summary>Gets or sets a boolean indicating if there should be a newline before the OUTPUT clause</Summary>
     </Setting>
-	<Setting name="NewLineBeforeBinaryBooleanExpresson" type="bool" default="true">
-	  <Summary>Gets or sets a boolean indicating if there should be a newline before the AND/OR keyword</Summary>
-	</Setting>
-	<Setting name="NewLineAfterBinaryBooleanExpresson" type="bool" default="false">
-	  <Summary>Gets or sets a boolean indicating if there should be a newline after the AND/OR keyword</Summary>
-	</Setting>
+  	<Setting name="NewLineBeforeBinaryBooleanExpresson" type="bool" default="true">
+  	  <Summary>Gets or sets a boolean indicating if there should be a newline before the AND/OR keyword</Summary>
+  	</Setting>
+  	<Setting name="NewLineAfterBinaryBooleanExpresson" type="bool" default="false">
+  	  <Summary>Gets or sets a boolean indicating if there should be a newline after the AND/OR keyword</Summary>
+  	</Setting>
   </SettingGroup>
   <SettingGroup name="Alignment">
     <Setting name="AlignClauseBodies" type="bool" default="true">

--- a/SqlScriptDom/ScriptDom/SqlServer/Settings/SqlScriptGeneratorOptions.xml
+++ b/SqlScriptDom/ScriptDom/SqlServer/Settings/SqlScriptGeneratorOptions.xml
@@ -38,15 +38,33 @@
     <Setting name="NewLineBeforeFromClause" type="bool" default="true">
       <Summary>Gets or sets a boolean indicating if there should be a newline before the FROM clause in a SELECT statement</Summary>
     </Setting>
+	<Setting name="NewLineAfterFromClause" type="bool" default="false">
+	  <Summary>Gets or sets a boolean indicating if there should be a newline after the FROM clause in a SELECT statement</Summary>
+	</Setting>
+	<Setting name="NewLineAfterSelectKeyword" type="bool" default="false">
+	  <Summary>Gets or sets a boolean indicating if there should be a newline after the SELECT in a SELECT statement</Summary>
+	</Setting>
+	 <Setting name="NewLineAfterWhereKeyword" type="bool" default="false">
+	  <Summary>Gets or sets a boolean indicating if there should be a newline after the WHERE keyword in a WHERE clause</Summary>
+	 </Setting>
     <Setting name="NewLineBeforeWhereClause" type="bool" default="true">
       <Summary>Gets or sets a boolean indicating if there should be a newline before the WHERE clause in a SELECT statement</Summary>
     </Setting>
+	<Setting name="NewLineAfterGroupByKeyword" type="bool" default="true">
+	 <Summary>Gets or sets a boolean indicating if there should be a newline after the GROUP BY keyword in a GROUP BY clause</Summary>
+	</Setting>
     <Setting name="NewLineBeforeGroupByClause" type="bool" default="true">
       <Summary>Gets or sets a boolean indicating if there should be a newline before the GROUP BY clause in a SELECT statement</Summary>
     </Setting>
+	<Setting name="NewLineAfterOrderByKeyword" type="bool" default="true">
+	  <Summary>Gets or sets a boolean indicating if there should be a newline after the ORDER BY keyword in a GROUP BY clause</Summary>
+	</Setting>
     <Setting name="NewLineBeforeOrderByClause" type="bool" default="true">
       <Summary>Gets or sets a boolean indicating if there should be a newline before the ORDER BY clause in a SELECT statement</Summary>
     </Setting>
+	<Setting name="NewLineAfterHavingKeyword" type="bool" default="true">
+	  <Summary>Gets or sets a boolean indicating if there should be a newline after the HAVING keyword in a GROUP BY clause</Summary>
+	</Setting>
     <Setting name="NewLineBeforeHavingClause" type="bool" default="true">
       <Summary>Gets or sets a boolean indicating if there should be a newline before the HAVING clause in a SELECT statement</Summary>
     </Setting>
@@ -56,12 +74,24 @@
     <Setting name="NewLineBeforeJoinClause" type="bool" default="true">
       <Summary>Gets or sets a boolean indicating if there should be a newline before the JOIN clause in a SELECT statement</Summary>
     </Setting>
+	<Setting name="NewLineBeforeOnKeyword" type="bool" default="true">
+	  <Summary>Gets or sets a boolean indicating if there should be a newline before the ON keyword in a JOIN clause</Summary>
+	</Setting>
+	<Setting name="NewLineAfterOnKeyword" type="bool" default="false">
+	  <Summary>Gets or sets a boolean indicating if there should be a newline after the ON keyword in a JOIN clause</Summary>
+	</Setting>
     <Setting name="NewLineBeforeOffsetClause" type="bool" default="true">
       <Summary>Gets or sets a boolean indicating if there should be a newline before the OFFSET clause</Summary>
     </Setting>
     <Setting name="NewLineBeforeOutputClause" type="bool" default="true">
       <Summary>Gets or sets a boolean indicating if there should be a newline before the OUTPUT clause</Summary>
     </Setting>
+	<Setting name="NewLineBeforeBinaryBooleanExpresson" type="bool" default="true">
+	  <Summary>Gets or sets a boolean indicating if there should be a newline before the AND/OR keyword</Summary>
+	</Setting>
+	<Setting name="NewLineAfterBinaryBooleanExpresson" type="bool" default="false">
+	  <Summary>Gets or sets a boolean indicating if there should be a newline after the AND/OR keyword</Summary>
+	</Setting>
   </SettingGroup>
   <SettingGroup name="Alignment">
     <Setting name="AlignClauseBodies" type="bool" default="true">

--- a/SqlScriptDom/ScriptDom/SqlServer/Settings/SqlScriptGeneratorOptions.xml
+++ b/SqlScriptDom/ScriptDom/SqlServer/Settings/SqlScriptGeneratorOptions.xml
@@ -39,32 +39,32 @@
       <Summary>Gets or sets a boolean indicating if there should be a newline before the FROM clause in a SELECT statement</Summary>
     </Setting>
     <Setting name="NewLineAfterFromClause" type="bool" default="false">
-  	  <Summary>Gets or sets a boolean indicating if there should be a newline after the FROM clause in a SELECT statement</Summary>
-  	</Setting>
-  	<Setting name="NewLineAfterSelectKeyword" type="bool" default="false">
-  	  <Summary>Gets or sets a boolean indicating if there should be a newline after the SELECT in a SELECT statement</Summary>
-  	</Setting>
-  	<Setting name="NewLineAfterWhereKeyword" type="bool" default="false">
-  	  <Summary>Gets or sets a boolean indicating if there should be a newline after the WHERE keyword in a WHERE clause</Summary>
-  	</Setting>
+      <Summary>Gets or sets a boolean indicating if there should be a newline after the FROM clause in a SELECT statement</Summary>
+    </Setting>
+    <Setting name="NewLineAfterSelectKeyword" type="bool" default="false">
+      <Summary>Gets or sets a boolean indicating if there should be a newline after the SELECT in a SELECT statement</Summary>
+    </Setting>
+    <Setting name="NewLineAfterWhereKeyword" type="bool" default="false">
+      <Summary>Gets or sets a boolean indicating if there should be a newline after the WHERE keyword in a WHERE clause</Summary>
+    </Setting>
     <Setting name="NewLineBeforeWhereClause" type="bool" default="true">
       <Summary>Gets or sets a boolean indicating if there should be a newline before the WHERE clause in a SELECT statement</Summary>
     </Setting>
-  	<Setting name="NewLineAfterGroupByKeyword" type="bool" default="false">
-  	  <Summary>Gets or sets a boolean indicating if there should be a newline after the GROUP BY keyword in a GROUP BY clause</Summary>
-  	</Setting>
+    <Setting name="NewLineAfterGroupByKeyword" type="bool" default="false">
+      <Summary>Gets or sets a boolean indicating if there should be a newline after the GROUP BY keyword in a GROUP BY clause</Summary>
+    </Setting>
     <Setting name="NewLineBeforeGroupByClause" type="bool" default="true">
       <Summary>Gets or sets a boolean indicating if there should be a newline before the GROUP BY clause in a SELECT statement</Summary>
     </Setting>
-  	<Setting name="NewLineAfterOrderByKeyword" type="bool" default="false">
-  	  <Summary>Gets or sets a boolean indicating if there should be a newline after the ORDER BY keyword in a GROUP BY clause</Summary>
-  	</Setting>
+    <Setting name="NewLineAfterOrderByKeyword" type="bool" default="false">
+      <Summary>Gets or sets a boolean indicating if there should be a newline after the ORDER BY keyword in a GROUP BY clause</Summary>
+    </Setting>
     <Setting name="NewLineBeforeOrderByClause" type="bool" default="true">
       <Summary>Gets or sets a boolean indicating if there should be a newline before the ORDER BY clause in a SELECT statement</Summary>
     </Setting>
-  	<Setting name="NewLineAfterHavingKeyword" type="bool" default="false">
-  	  <Summary>Gets or sets a boolean indicating if there should be a newline after the HAVING keyword in a GROUP BY clause</Summary>
-  	</Setting>
+    <Setting name="NewLineAfterHavingKeyword" type="bool" default="false">
+      <Summary>Gets or sets a boolean indicating if there should be a newline after the HAVING keyword in a GROUP BY clause</Summary>
+    </Setting>
     <Setting name="NewLineBeforeHavingClause" type="bool" default="true">
       <Summary>Gets or sets a boolean indicating if there should be a newline before the HAVING clause in a SELECT statement</Summary>
     </Setting>
@@ -74,24 +74,24 @@
     <Setting name="NewLineBeforeJoinClause" type="bool" default="true">
       <Summary>Gets or sets a boolean indicating if there should be a newline before the JOIN clause in a SELECT statement</Summary>
     </Setting>
-  	<Setting name="NewLineBeforeOnKeyword" type="bool" default="true">
-  	  <Summary>Gets or sets a boolean indicating if there should be a newline before the ON keyword in a JOIN clause</Summary>
-  	</Setting>
-  	<Setting name="NewLineAfterOnKeyword" type="bool" default="false">
-  	  <Summary>Gets or sets a boolean indicating if there should be a newline after the ON keyword in a JOIN clause</Summary>
-  	</Setting>
+    <Setting name="NewLineBeforeOnKeyword" type="bool" default="true">
+      <Summary>Gets or sets a boolean indicating if there should be a newline before the ON keyword in a JOIN clause</Summary>
+    </Setting>
+    <Setting name="NewLineAfterOnKeyword" type="bool" default="false">
+      <Summary>Gets or sets a boolean indicating if there should be a newline after the ON keyword in a JOIN clause</Summary>
+    </Setting>
     <Setting name="NewLineBeforeOffsetClause" type="bool" default="true">
       <Summary>Gets or sets a boolean indicating if there should be a newline before the OFFSET clause</Summary>
     </Setting>
     <Setting name="NewLineBeforeOutputClause" type="bool" default="true">
       <Summary>Gets or sets a boolean indicating if there should be a newline before the OUTPUT clause</Summary>
     </Setting>
-  	<Setting name="NewLineBeforeBinaryBooleanExpresson" type="bool" default="true">
-  	  <Summary>Gets or sets a boolean indicating if there should be a newline before the AND/OR keyword</Summary>
-  	</Setting>
-  	<Setting name="NewLineAfterBinaryBooleanExpresson" type="bool" default="false">
-  	  <Summary>Gets or sets a boolean indicating if there should be a newline after the AND/OR keyword</Summary>
-  	</Setting>
+    <Setting name="NewLineBeforeBinaryBooleanExpresson" type="bool" default="true">
+      <Summary>Gets or sets a boolean indicating if there should be a newline before the AND/OR keyword</Summary>
+    </Setting>
+    <Setting name="NewLineAfterBinaryBooleanExpresson" type="bool" default="false">
+      <Summary>Gets or sets a boolean indicating if there should be a newline after the AND/OR keyword</Summary>
+    </Setting>
   </SettingGroup>
   <SettingGroup name="Alignment">
     <Setting name="AlignClauseBodies" type="bool" default="true">

--- a/SqlScriptDom/ScriptDom/SqlServer/Settings/SqlScriptGeneratorOptions.xml
+++ b/SqlScriptDom/ScriptDom/SqlServer/Settings/SqlScriptGeneratorOptions.xml
@@ -50,19 +50,19 @@
     <Setting name="NewLineBeforeWhereClause" type="bool" default="true">
       <Summary>Gets or sets a boolean indicating if there should be a newline before the WHERE clause in a SELECT statement</Summary>
     </Setting>
-	<Setting name="NewLineAfterGroupByKeyword" type="bool" default="true">
+	<Setting name="NewLineAfterGroupByKeyword" type="bool" default="false">
 	 <Summary>Gets or sets a boolean indicating if there should be a newline after the GROUP BY keyword in a GROUP BY clause</Summary>
 	</Setting>
     <Setting name="NewLineBeforeGroupByClause" type="bool" default="true">
       <Summary>Gets or sets a boolean indicating if there should be a newline before the GROUP BY clause in a SELECT statement</Summary>
     </Setting>
-	<Setting name="NewLineAfterOrderByKeyword" type="bool" default="true">
+	<Setting name="NewLineAfterOrderByKeyword" type="bool" default="false">
 	  <Summary>Gets or sets a boolean indicating if there should be a newline after the ORDER BY keyword in a GROUP BY clause</Summary>
 	</Setting>
     <Setting name="NewLineBeforeOrderByClause" type="bool" default="true">
       <Summary>Gets or sets a boolean indicating if there should be a newline before the ORDER BY clause in a SELECT statement</Summary>
     </Setting>
-	<Setting name="NewLineAfterHavingKeyword" type="bool" default="true">
+	<Setting name="NewLineAfterHavingKeyword" type="bool" default="false">
 	  <Summary>Gets or sets a boolean indicating if there should be a newline after the HAVING keyword in a GROUP BY clause</Summary>
 	</Setting>
     <Setting name="NewLineBeforeHavingClause" type="bool" default="true">


### PR DESCRIPTION
I added options to the formatting so that we can have keywords at the end of the line vs the beginning:

```
SELECT
    Table1.Column1,
    Table2.Column2
FROM
    Table1 INNER JOIN
    Table2 ON
        Table1.Column1 = Table2.Column1 AND
        Table1.ColumnX = Table2.ColumnX
WHERE
    Condition1 = 1 AND
    Condition2 = 2
```
