### PR TITLE
Add generator option for newlines between statements

### DIFF
--- a/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGeneratorVisitor.StatementList.cs
+++ b/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGeneratorVisitor.StatementList.cs
@@ -23,7 +23,10 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom.ScriptGenerator
                     }
                     else
                     {
-                        NewLine();
+                        for (var i = 0; i < _options.NumNewlinesAfterStatement; i++)
+                        {
+                            NewLine();
+                        }
                     }
 
                     GenerateFragmentIfNotNull(statement);

--- a/SqlScriptDom/ScriptDom/SqlServer/Settings/SqlScriptGeneratorOptions.xml
+++ b/SqlScriptDom/ScriptDom/SqlServer/Settings/SqlScriptGeneratorOptions.xml
@@ -28,6 +28,9 @@
       <Description>IncludeSemiColons_Description</Description>
       <Summary>Gets or sets a boolean indicating if a semi colon should be included after each statement</Summary>
     </Setting>
+    <Setting name="NumNewlinesAfterStatement" type="int" default="1" min="0">
+      <Summary>Gets or sets the number of newlines to include after each statement</Summary>
+    </Setting>
   </SettingGroup>
   <SettingGroup name="CREATE TABLE">
     <Setting name="AlignColumnDefinitionFields" type="bool" default="true">


### PR DESCRIPTION
Currently the generator only generates one newline between statements which leads to code like this:

```sql
CREATE TABLE [MyTable] (
  ...
);
ALTER TABLE [MyTable]
  ...;
```

Which can be unfavourable, I've added a script generator option that allows you to specify how many newlines you want so you can get something like this instead:

```sql
CREATE TABLE [MyTable] (
  ...
);

ALTER TABLE [MyTable]
  ...;
```