### PR TITLE
adds wait at low pri support to create 2022+

### DIFF
--- a/SqlScriptDom/Parser/TSql/TSql150ParserBaseInternal.cs
+++ b/SqlScriptDom/Parser/TSql/TSql150ParserBaseInternal.cs
@@ -49,36 +49,9 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom
         protected static void VerifyAllowedIndexOption150(IndexAffectingStatement statement, IndexOption option)
         {
             VerifyAllowedIndexOption(statement, option, SqlVersionFlags.TSql150);
-            VerifyAllowedOnlineIndexOptionLowPriorityLockWait(statement, option);
+            VerifyAllowedOnlineIndexOptionLowPriorityLockWait(statement, option, SqlVersionFlags.TSql150);
         }
 
-        protected static void VerifyAllowedOnlineIndexOptionLowPriorityLockWait(IndexAffectingStatement statement, IndexOption option)
-        {
-            // for a low priority lock wait (MLP) option, check if it is allowed for the statement.
-            //
-            if (option is OnlineIndexOption)
-            {
-                OnlineIndexOption onlineIndexOption = option as OnlineIndexOption;
-                if (onlineIndexOption.LowPriorityLockWaitOption != null)
-                {
-                    switch (statement)
-                    {
-                        case IndexAffectingStatement.AlterIndexRebuildOnePartition:
-                        case IndexAffectingStatement.AlterTableRebuildOnePartition:
-                        case IndexAffectingStatement.AlterIndexRebuildAllPartitions:
-                        case IndexAffectingStatement.AlterTableRebuildAllPartitions:
-                            // allowed
-                            //
-                            break;
-
-                        default:
-                            // WAIT_AT_LOW_PRIORITY is not a valid index option in the statement
-                            //
-                            ThrowWrongIndexOptionError(statement, onlineIndexOption.LowPriorityLockWaitOption);
-                            break;
-                    }
-                }
-            }
-        }
+        
     }
 }

--- a/SqlScriptDom/Parser/TSql/TSql160ParserBaseInternal.cs
+++ b/SqlScriptDom/Parser/TSql/TSql160ParserBaseInternal.cs
@@ -53,7 +53,7 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom
         protected static void VerifyAllowedIndexOption160(IndexAffectingStatement statement, IndexOption option)
         {
             VerifyAllowedIndexOption(statement, option, SqlVersionFlags.TSql160);
-            VerifyAllowedOnlineIndexOptionLowPriorityLockWait(statement, option);
+            VerifyAllowedOnlineIndexOptionLowPriorityLockWait(statement, option, SqlVersionFlags.TSql160);
         }
 
         protected static SqlDataTypeOption ParseDataType160(string token)

--- a/Test/SqlDom/Baselines160/CreateIndexStatementTests160.sql
+++ b/Test/SqlDom/Baselines160/CreateIndexStatementTests160.sql
@@ -48,3 +48,6 @@ CREATE CLUSTERED INDEX tableWithClusteredIndex_index
 
 CREATE UNIQUE INDEX tableWithUniqueIndex_index
     ON dbo.tableWithUniqueIndex(c1) WITH (XML_COMPRESSION = ON);
+
+CREATE CLUSTERED INDEX idx_1
+    ON dbo.T2(a) WITH (ONLINE = ON (WAIT_AT_LOW_PRIORITY (MAX_DURATION = 5 MINUTES, ABORT_AFTER_WAIT = SELF)));

--- a/Test/SqlDom/Only160SyntaxTests.cs
+++ b/Test/SqlDom/Only160SyntaxTests.cs
@@ -23,7 +23,7 @@ namespace SqlStudio.Tests.UTSqlScriptDom
             new ParserTest160("CreateExternalDataSourceStatementTests160.sql", nErrors80: 2, nErrors90: 2, nErrors100: 2, nErrors110: 2, nErrors120: 2, nErrors130: 0, nErrors140: 0, nErrors150: 0),
             new ParserTest160("CreateDatabaseTests160.sql", nErrors80: 4, nErrors90: 4, nErrors100: 4, nErrors110: 4, nErrors120: 4, nErrors130: 4, nErrors140: 4, nErrors150: 4),
             new ParserTest160("CreateLedgerTableTests160.sql", nErrors80: 14, nErrors90: 14, nErrors100: 14, nErrors110: 14, nErrors120: 14, nErrors130: 14, nErrors140: 14, nErrors150: 14),
-            new ParserTest160("CreateIndexStatementTests160.sql", nErrors80: 12, nErrors90: 16, nErrors100: 14, nErrors110: 14, nErrors120: 14, nErrors130: 14, nErrors140: 14, nErrors150: 14),
+            new ParserTest160("CreateIndexStatementTests160.sql", nErrors80: 12, nErrors90: 17, nErrors100: 15, nErrors110: 15, nErrors120: 15, nErrors130: 15, nErrors140: 15, nErrors150: 15),
             new ParserTest160("MergeStatementTests160.sql", nErrors80: 1, nErrors90: 5, nErrors100: 5, nErrors110: 5, nErrors120: 5, nErrors130: 5, nErrors140: 5, nErrors150: 5),
             new ParserTest160("SelectStatementTests160.sql", nErrors80: 5, nErrors90: 5, nErrors100: 5, nErrors110: 5, nErrors120: 5, nErrors130: 5, nErrors140: 5, nErrors150: 5),
             new ParserTest160("CreateTableTests160.sql", nErrors80: 11, nErrors90: 11, nErrors100: 11, nErrors110: 11, nErrors120: 11, nErrors130: 7, nErrors140: 7, nErrors150: 7),

--- a/Test/SqlDom/TestScripts/CreateIndexStatementTests160.sql
+++ b/Test/SqlDom/TestScripts/CreateIndexStatementTests160.sql
@@ -43,3 +43,5 @@ CREATE CLUSTERED INDEX tableWithClusteredIndex_index ON dbo.tableWithClusteredIn
 
 -- Unique index
 CREATE UNIQUE INDEX tableWithUniqueIndex_index ON dbo.tableWithUniqueIndex (c1) WITH (XML_COMPRESSION = ON);
+
+CREATE CLUSTERED INDEX idx_1 ON dbo.T2 (a) WITH (ONLINE = ON (WAIT_AT_LOW_PRIORITY (MAX_DURATION = 5 MINUTES, ABORT_AFTER_WAIT = SELF)));


### PR DESCRIPTION
fixes #102 

https://learn.microsoft.com/en-us/sql/t-sql/statements/create-index-transact-sql?view=sql-server-ver16#wait-at-low-priority
SQL 2022 extended wait_at_low_priority to also apply to create index