### PR TITLE
fixing a bug with parsing json value with multi name columns

### DIFF
--- a/SqlScriptDom/Parser/TSql/TSql170.g
+++ b/SqlScriptDom/Parser/TSql/TSql170.g
@@ -32520,30 +32520,33 @@ jsonKeyValueExpression returns [JsonKeyValue vResult = FragmentFactory.CreateFra
 {
     ScalarExpression vKey;
     ScalarExpression vValue;
+    MultiPartIdentifier vMultiPartIdentifier = null;
 }
     : 
         (
+            (vMultiPartIdentifier=multiPartIdentifier[2] Dot)? label:Label
+            {
+                var identifier = this.FragmentFactory.CreateFragment<Identifier>();
+                if (vMultiPartIdentifier == null)
+                {
+                    vMultiPartIdentifier = this.FragmentFactory.CreateFragment<MultiPartIdentifier>();
+                }
+                var columnRef = this.FragmentFactory.CreateFragment<ColumnReferenceExpression>();
+                CreateIdentifierFromLabel(label, identifier, vMultiPartIdentifier);
+
+                columnRef.MultiPartIdentifier = vMultiPartIdentifier;
+                vResult.JsonKeyName=columnRef;
+            }
+            vValue=expression 
+            {            
+                vResult.JsonValue=vValue;
+            }
+        |
             vKey=expression
             {           
                 vResult.JsonKeyName=vKey;
             }
             Colon vValue=expression 
-            {            
-                vResult.JsonValue=vValue;
-            }
-       
-        |   
-        
-            label:Label
-            {
-                var identifier = this.FragmentFactory.CreateFragment<Identifier>();
-                var multiPartIdentifier = this.FragmentFactory.CreateFragment<MultiPartIdentifier>();
-                var columnRef = this.FragmentFactory.CreateFragment<ColumnReferenceExpression>();
-                CreateIdentifierFromLabel(label, identifier, multiPartIdentifier);
-                columnRef.MultiPartIdentifier = multiPartIdentifier;
-                vResult.JsonKeyName=columnRef;
-            }
-            vValue=expression 
             {            
                 vResult.JsonValue=vValue;
             }

--- a/Test/SqlDom/Baselines170/JsonFunctionTests170.sql
+++ b/Test/SqlDom/Baselines170/JsonFunctionTests170.sql
@@ -133,3 +133,9 @@ CREATE VIEW dbo.jsonfunctest
 AS
 SELECT JSON_OBJECTAGG(c1:c2) AS jsoncontents
 FROM (VALUES ('key1', 'c'), ('key2', 'b'), ('key3', 'a')) AS t(c1, c2);
+
+GO
+SELECT TOP (5) c.object_id,
+               JSON_OBJECTAGG(c.name:c.column_id) AS columns
+FROM sys.columns AS c
+GROUP BY c.object_id;

--- a/Test/SqlDom/Only170SyntaxTests.cs
+++ b/Test/SqlDom/Only170SyntaxTests.cs
@@ -1,7 +1,9 @@
 ﻿using Microsoft.SqlServer.TransactSql.ScriptDom;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SqlStudio.Tests.AssemblyTools.TestCategory;
+using System;
 using System.Collections.Generic;
+using System.IO;
 
 namespace SqlStudio.Tests.UTSqlScriptDom
 {
@@ -17,7 +19,7 @@ namespace SqlStudio.Tests.UTSqlScriptDom
             new ParserTest170("CreateColumnStoreIndexTests170.sql", nErrors80: 3, nErrors90: 3, nErrors100: 3, nErrors110: 3, nErrors120: 3, nErrors130: 0, nErrors140: 0, nErrors150: 0, nErrors160: 0),
             new ParserTest170("RegexpTests170.sql", nErrors80: 0, nErrors90: 0, nErrors100: 0, nErrors110: 0, nErrors120: 0, nErrors130: 0, nErrors140: 0, nErrors150: 0, nErrors160: 0),
             new ParserTest170("AiGenerateChunksTests170.sql", nErrors80: 19, nErrors90: 16, nErrors100: 15, nErrors110: 15, nErrors120: 15, nErrors130: 15, nErrors140: 15, nErrors150: 15, nErrors160: 15),
-            new ParserTest170("JsonFunctionTests170.sql", nErrors80: 10, nErrors90: 8, nErrors100: 35, nErrors110: 35, nErrors120: 35, nErrors130: 35, nErrors140: 35, nErrors150: 35, nErrors160: 35),
+            new ParserTest170("JsonFunctionTests170.sql", nErrors80: 11, nErrors90: 8, nErrors100: 36, nErrors110: 36, nErrors120: 36, nErrors130: 36, nErrors140: 36, nErrors150: 36, nErrors160: 36),
             new ParserTest170("AiGenerateEmbeddingsTests170.sql", nErrors80: 12, nErrors90: 9, nErrors100: 9, nErrors110: 9, nErrors120: 9, nErrors130: 9, nErrors140: 9, nErrors150: 9, nErrors160: 9),
             new ParserTest170("CreateExternalModelStatementTests170.sql", nErrors80: 2, nErrors90: 2, nErrors100: 2, nErrors110: 2, nErrors120: 2, nErrors130: 4, nErrors140: 4, nErrors150: 4, nErrors160: 4),
             new ParserTest170("AlterExternalModelStatementTests170.sql", nErrors80: 2, nErrors90: 2, nErrors100: 2, nErrors110: 2, nErrors120: 2, nErrors130: 5, nErrors140: 5, nErrors150: 5, nErrors160: 5),

--- a/Test/SqlDom/TestScripts/JsonFunctionTests170.sql
+++ b/Test/SqlDom/TestScripts/JsonFunctionTests170.sql
@@ -128,3 +128,8 @@ CREATE VIEW dbo.jsonfunctest AS
                     FROM (
                     VALUES('key1', 'c'), ('key2', 'b'), ('key3','a')
                     ) AS t(c1, c2);
+
+GO
+SELECT TOP(5) c.object_id, JSON_OBJECTAGG(c.name:c.column_id) AS columns
+  FROM sys.columns AS c
+ GROUP BY c.object_id;


### PR DESCRIPTION
# Description

Fixing a bug parsing TSQL:
SELECT TOP(5) c.object_id, JSON_OBJECTAGG(c.name:c.column_id) AS columns
  FROM sys.columns AS c
 GROUP BY c.object_id;

In addition, go through the checklist below and check each item as you validate it is either handled or not applicable to this change.

# Code Changes

- [ ] [Unit tests](https://github.com/microsoft/SqlScriptDOM/tree/main/Test) are added, if possible
- [ ] Existing [tests are passing](https://github.com/microsoft/SqlScriptDOM/blob/main/CONTRIBUTING.md#running-the-tests)
- [ ] New or updated code follows the guidelines [here](https://github.com/microsoft/SqlScriptDOM/blob/main/CONTRIBUTING.md#helpful-notes-for-sqldom-extensions)

