### PR TITLE
linux ci troubleshooting step

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -20,7 +20,7 @@ jobs:
       run: dotnet build dirs.proj
     - name: Archive antlr log for troubleshooting
       if: ${{ failure() && matrix.os == 'ubuntu-latest' }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: antlr-log
         path: SqlScriptDom/NUL

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -18,6 +18,12 @@ jobs:
       run: dotnet restore
     - name: Build
       run: dotnet build dirs.proj
+    - name: Archive antlr log for troubleshooting
+      if: ${{ failure() && matrix.os == 'ubuntu-latest' }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: antlr-log
+        path: SqlScriptDom/NUL
   test: 
     runs-on: ${{ matrix.os }}
     strategy:

--- a/SqlScriptDom/Parser/TSql/TSql170.g
+++ b/SqlScriptDom/Parser/TSql/TSql170.g
@@ -13,7 +13,7 @@
 // Also for token that we don't track of like Comma, Semicolon etc. we have to
 // call the same function.  Alternatively the properties(StartOffset, FragmentLength)
 // on Fragment.cs can be used for this purpose.
-
+'
 options {
     language = "CSharp";
     namespace = "Microsoft.SqlServer.TransactSql.ScriptDom";

--- a/SqlScriptDom/Parser/TSql/TSql170.g
+++ b/SqlScriptDom/Parser/TSql/TSql170.g
@@ -13,7 +13,7 @@
 // Also for token that we don't track of like Comma, Semicolon etc. we have to
 // call the same function.  Alternatively the properties(StartOffset, FragmentLength)
 // on Fragment.cs can be used for this purpose.
-'
+
 options {
     language = "CSharp";
     namespace = "Microsoft.SqlServer.TransactSql.ScriptDom";


### PR DESCRIPTION
# Description

Adding a CI step for linux jobs to output the antlr log to an archived file, making troubleshooting CI easier. Linux CI is more sensitive to characters in the grammar files

<img width="500" height="863" alt="image" src="https://github.com/user-attachments/assets/665428bf-4b2d-4123-bf78-4dab3381ae46" />

antlr-log.zip extracts to `NUL` file, which contains the grammar errors.

in this case:

```log
ANTLR Parser Generator   Version 2.7.5 (20050128)   1989-2005 jGuru.com
error: Token stream error reading grammar(s):
/home/runner/work/SqlScriptDOM/SqlScriptDOM/SqlScriptDom/Parser/TSql/TSql170.g:16:3: expecting ''', found 'o'
TokenStreamException: expecting ''', found 'o'
```

# Code Changes

- [x] [Unit tests](https://github.com/microsoft/SqlScriptDOM/tree/main/Test) are added, if possible
- [x] Existing [tests are passing](https://github.com/microsoft/SqlScriptDOM/blob/main/CONTRIBUTING.md#running-the-tests)
- [x] New or updated code follows the guidelines [here](https://github.com/microsoft/SqlScriptDOM/blob/main/CONTRIBUTING.md#helpful-notes-for-sqldom-extensions)

