### PR TITLE
Place semicolon before inline comment

### DIFF
--- a/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGeneratorVisitor.Comments.cs
+++ b/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGeneratorVisitor.Comments.cs
@@ -33,6 +33,20 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom.ScriptGenerator
         /// </summary>
         private bool _leadingCommentsEmitted = false;
 
+        /// <summary>
+        /// When true, suppresses trailing comment emission in HandleCommentsAfterFragment
+        /// for fragments whose LastTokenIndex matches or exceeds _suppressTrailingCommentsAfterIndex.
+        /// Used by GenerateStatementWithSemiColon to defer trailing comments until after
+        /// the semicolon has been placed, without affecting inter-clause comments.
+        /// </summary>
+        private bool _suppressTrailingComments = false;
+
+        /// <summary>
+        /// The LastTokenIndex of the statement for which trailing comments are being suppressed.
+        /// Only comments after this index are suppressed.
+        /// </summary>
+        private int _suppressTrailingCommentsAfterIndex = -1;
+
         #endregion
 
         #region Comment Preservation Methods
@@ -48,6 +62,8 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom.ScriptGenerator
             _lastProcessedTokenIndex = -1;
             _emittedComments.Clear();
             _leadingCommentsEmitted = false;
+            _suppressTrailingComments = false;
+            _suppressTrailingCommentsAfterIndex = -1;
         }
 
         /// <summary>
@@ -189,6 +205,16 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom.ScriptGenerator
         {
             if (!_options.PreserveComments || _currentTokenStream == null || fragment == null)
             {
+                return;
+            }
+
+            // When trailing comments are suppressed (e.g., during statement body generation
+            // before semicolon placement), skip emitting trailing comments only for fragments
+            // whose last token is at or past the statement boundary. Inter-clause comments
+            // (within the statement) are still emitted normally.
+            if (_suppressTrailingComments && fragment.LastTokenIndex >= _suppressTrailingCommentsAfterIndex)
+            {
+                UpdateLastProcessedIndex(fragment);
                 return;
             }
 

--- a/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGeneratorVisitor.CommonPhrases.cs
+++ b/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGeneratorVisitor.CommonPhrases.cs
@@ -440,6 +440,46 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom.ScriptGenerator
             }
         }
 
+        /// <summary>
+        /// Generates a statement fragment with semicolon placed before any trailing comments.
+        /// This prevents semicolons from being appended after single-line comments (-- style),
+        /// which would make them part of the comment text.
+        /// </summary>
+        protected void GenerateStatementWithSemiColon(TSqlStatement statement)
+        {
+            if (statement == null)
+            {
+                return;
+            }
+
+            // Handle comments before
+            HandleCommentsBeforeFragment(statement);
+
+            // Suppress trailing comment emission during statement body generation
+            // so that the semicolon can be placed before trailing comments.
+            // Only suppress for fragments at the statement boundary (LastTokenIndex).
+            bool previousSuppressState = _suppressTrailingComments;
+            int previousSuppressIndex = _suppressTrailingCommentsAfterIndex;
+            if (_options.PreserveComments && _generateSemiColon && !StatementsThatCannotHaveSemiColon.Contains(statement.GetType()))
+            {
+                _suppressTrailingComments = true;
+                _suppressTrailingCommentsAfterIndex = statement.LastTokenIndex;
+            }
+
+            // Generate the statement body
+            statement.Accept(this);
+
+            // Restore suppression state and emit semicolon before trailing comments
+            _suppressTrailingComments = previousSuppressState;
+            _suppressTrailingCommentsAfterIndex = previousSuppressIndex;
+
+            // Semicolon BEFORE trailing comments
+            GenerateSemiColonWhenNecessary(statement);
+
+            // Now emit trailing comments (after the semicolon)
+            HandleCommentsAfterFragment(statement);
+        }
+		
         protected void GenerateCommaSeparatedWithClause<T>(IList<T> fragments, bool indent, bool includeParentheses) where T : TSqlFragment
         {
             if (fragments != null && fragments.Count > 0)

--- a/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGeneratorVisitor.IfStatement.cs
+++ b/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGeneratorVisitor.IfStatement.cs
@@ -18,8 +18,7 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom.ScriptGenerator
 
             NewLineAndIndent();
             MarkAndPushAlignmentPoint(branchStatements);
-            GenerateFragmentIfNotNull(node.ThenStatement);
-            GenerateSemiColonWhenNecessary(node.ThenStatement);
+            GenerateStatementWithSemiColon(node.ThenStatement);
             PopAlignmentPoint();
 
             if (node.ElseStatement != null)
@@ -28,8 +27,7 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom.ScriptGenerator
                 GenerateKeyword(TSqlTokenType.Else);
                 NewLineAndIndent();
                 MarkAndPushAlignmentPoint(branchStatements);
-                GenerateFragmentIfNotNull(node.ElseStatement);
-                GenerateSemiColonWhenNecessary(node.ElseStatement);
+                GenerateStatementWithSemiColon(node.ElseStatement);
                 PopAlignmentPoint();
             }
         }

--- a/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGeneratorVisitor.StatementList.cs
+++ b/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGeneratorVisitor.StatementList.cs
@@ -29,8 +29,7 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom.ScriptGenerator
                         }
                     }
 
-                    GenerateFragmentIfNotNull(statement);
-                    GenerateSemiColonWhenNecessary(statement);
+                    GenerateStatementWithSemiColon(statement);
                 }
             }
         }

--- a/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGeneratorVisitor.TSqlBatch.cs
+++ b/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGeneratorVisitor.TSqlBatch.cs
@@ -13,9 +13,7 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom.ScriptGenerator
         {
             foreach (TSqlStatement statement in node.Statements)
             {
-                GenerateFragmentIfNotNull(statement);
-
-                GenerateSemiColonWhenNecessary(statement);
+                GenerateStatementWithSemiColon(statement);
 
                 if (statement is TSqlStatementSnippet == false)
                 {

--- a/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGeneratorVisitor.WhileStatement.cs
+++ b/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGeneratorVisitor.WhileStatement.cs
@@ -18,8 +18,7 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom.ScriptGenerator
 
             NewLineAndIndent();
             MarkAndPushAlignmentPoint(whileBody);
-            GenerateFragmentIfNotNull(node.Statement);
-            GenerateSemiColonWhenNecessary(node.Statement);
+            GenerateStatementWithSemiColon(node.Statement);
             PopAlignmentPoint();
         }
     }

--- a/Test/SqlDom/ScriptGeneratorTests.cs
+++ b/Test/SqlDom/ScriptGeneratorTests.cs
@@ -1256,6 +1256,102 @@ SELECT id, name FROM archived_users;";
                 $"inner_q alias should appear before outer_q alias. inner_q at {innerQAliasIdx}, outer_q at {outerQAliasIdx}");
         }
 
+        [TestMethod]
+        [Priority(0)]
+        [SqlStudioTestCategory(Category.UnitTest)]
+        public void TestPreserveCommentsEnabled_SemicolonBeforeTrailingComment()
+        {
+            // Test that semicolons are placed BEFORE trailing single-line comments,
+            // not after them (which would make the semicolon part of the comment text).
+            // Bug fix: previously "SELECT 1 -- comment;" was generated instead of "SELECT 1; -- comment"
+            var sqlWithComments = "SELECT 1 -- trailing comment";
+            var parser = new TSql170Parser(true);
+            var fragment = parser.Parse(new StringReader(sqlWithComments), out var errors);
+
+            Assert.AreEqual(0, errors.Count);
+
+            var generatorOptions = new SqlScriptGeneratorOptions
+            {
+                PreserveComments = true,
+                IncludeSemicolons = true
+            };
+            var generator = new Sql170ScriptGenerator(generatorOptions);
+            generator.GenerateScript(fragment, out var generatedSql);
+
+            // The semicolon must appear BEFORE the trailing comment
+            int semicolonIndex = generatedSql.IndexOf(";");
+            int commentIndex = generatedSql.IndexOf("-- trailing comment");
+
+            Assert.IsTrue(semicolonIndex >= 0, "Semicolon should be present in output. Actual: " + generatedSql);
+            Assert.IsTrue(commentIndex >= 0, "Trailing comment should be preserved. Actual: " + generatedSql);
+            Assert.IsTrue(semicolonIndex < commentIndex,
+                $"Semicolon should appear before trailing comment. Semicolon at {semicolonIndex}, comment at {commentIndex}. Actual: " + generatedSql);
+        }
+
+        [TestMethod]
+        [Priority(0)]
+        [SqlStudioTestCategory(Category.UnitTest)]
+        public void TestPreserveCommentsEnabled_SemicolonBeforeTrailingComment_MultipleStatements()
+        {
+            // Test semicolon placement with multiple statements each having trailing comments
+            var sqlWithComments = @"SELECT 1 -- first comment
+SELECT 2 -- second comment";
+            var parser = new TSql170Parser(true);
+            var fragment = parser.Parse(new StringReader(sqlWithComments), out var errors);
+
+            Assert.AreEqual(0, errors.Count);
+
+            var generatorOptions = new SqlScriptGeneratorOptions
+            {
+                PreserveComments = true,
+                IncludeSemicolons = true
+            };
+            var generator = new Sql170ScriptGenerator(generatorOptions);
+            generator.GenerateScript(fragment, out var generatedSql);
+
+            // Both comments should be preserved
+            Assert.IsTrue(generatedSql.Contains("-- first comment"),
+                "First trailing comment should be preserved. Actual: " + generatedSql);
+            Assert.IsTrue(generatedSql.Contains("-- second comment"),
+                "Second trailing comment should be preserved. Actual: " + generatedSql);
+
+            // Verify semicolons appear before their respective comments, not after
+            Assert.IsFalse(generatedSql.Contains("-- first comment;"),
+                "Semicolon should not appear after first comment text. Actual: " + generatedSql);
+            Assert.IsFalse(generatedSql.Contains("-- second comment;"),
+                "Semicolon should not appear after second comment text. Actual: " + generatedSql);
+        }
+
+        [TestMethod]
+        [Priority(0)]
+        [SqlStudioTestCategory(Category.UnitTest)]
+        public void TestPreserveCommentsEnabled_SemicolonBeforeTrailingBlockComment()
+        {
+            // Test semicolon placement with trailing block comments
+            var sqlWithComments = "SELECT 1 /* trailing block comment */";
+            var parser = new TSql170Parser(true);
+            var fragment = parser.Parse(new StringReader(sqlWithComments), out var errors);
+
+            Assert.AreEqual(0, errors.Count);
+
+            var generatorOptions = new SqlScriptGeneratorOptions
+            {
+                PreserveComments = true,
+                IncludeSemicolons = true
+            };
+            var generator = new Sql170ScriptGenerator(generatorOptions);
+            generator.GenerateScript(fragment, out var generatedSql);
+
+            // The semicolon must appear BEFORE the trailing block comment
+            int semicolonIndex = generatedSql.IndexOf(";");
+            int commentIndex = generatedSql.IndexOf("/* trailing block comment */");
+
+            Assert.IsTrue(semicolonIndex >= 0, "Semicolon should be present in output. Actual: " + generatedSql);
+            Assert.IsTrue(commentIndex >= 0, "Trailing block comment should be preserved. Actual: " + generatedSql);
+            Assert.IsTrue(semicolonIndex < commentIndex,
+                $"Semicolon should appear before trailing block comment. Semicolon at {semicolonIndex}, comment at {commentIndex}. Actual: " + generatedSql);
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
Update the Transact-SQL script generator to ensure that semicolons are correctly placed before any trailing comments (both single-line and block comments) when generating SQL scripts with preserved comments. This prevents semicolons from being included as part of a comment, which could cause issues in SQL execution or readability.

The changes introduce a new method (`GenerateStatementWithSemiColon`) to handle this logic, and update all relevant code paths to use it.

- Added a new private state (`_suppressTrailingComments` and `_suppressTrailingCommentsAfterIndex`) and logic to the `SqlScriptGeneratorVisitor` to allow deferring the emission of trailing comments until after the semicolon is generated, ensuring the semicolon is not included in the comment text. [[1]](diffhunk://#diff-45341587dad9f40d76196244816f95519c3c1ade892556a8322647db380c7ee6R36-R49) [[2]](diffhunk://#diff-45341587dad9f40d76196244816f95519c3c1ade892556a8322647db380c7ee6R65-R66) [[3]](diffhunk://#diff-45341587dad9f40d76196244816f95519c3c1ade892556a8322647db380c7ee6R211-R220)
- Introduced the `GenerateStatementWithSemiColon` method, which generates a statement, emits the semicolon, and then emits any trailing comments. This method is now used in place of the previous approach wherever statements and their semicolons are generated.
- Updated all statement generation locations (`IfStatement`, `StatementList`, `TSqlBatch`, `WhileStatement`) to use `GenerateStatementWithSemiColon` instead of the old pattern, ensuring consistent semicolon placement before comments throughout the codebase. [[1]](diffhunk://#diff-baac723b23dc3b1e59033d2ef580ec9cfd3a8bf418a12fe806e9cbeb59c35d25L21-R21) [[2]](diffhunk://#diff-baac723b23dc3b1e59033d2ef580ec9cfd3a8bf418a12fe806e9cbeb59c35d25L31-R30) [[3]](diffhunk://#diff-57bf83c1835fbd2c180eca0298ac97469acc54d612135df184e3e8c3e3a5fd5dL32-R32) [[4]](diffhunk://#diff-e855484669a4c939ed6bc2da20be88b81ec494314c57d05147789060899d6724L16-R16) [[5]](diffhunk://#diff-69bfd26235c1966823f2567517fe0baf0b65799753878bebc466b406148fd457L21-R21)
- Added new unit tests to verify that semicolons are placed before trailing comments for single statements, multiple statements, and block comments, and that comments are preserved as expected. These tests ensure the new behavior works correctly and guards against regressions.

*(This description was generated with the assistance of Copilot.)*

In addition, go through the checklist below and check each item as you validate it is either handled or not applicable to this change.

# Code Changes

- [x] [Unit tests](https://github.com/microsoft/SqlScriptDOM/tree/main/Test) are added, if possible
- [x] Existing [tests are passing](https://github.com/microsoft/SqlScriptDOM/blob/main/CONTRIBUTING.md#running-the-tests)
- [x] New or updated code follows the guidelines [here](https://github.com/microsoft/SqlScriptDOM/blob/main/CONTRIBUTING.md#helpful-notes-for-sqldom-extensions)

