### PR TITLE
Add support for Query Hints for MS Fabric in TSql170Parser (#180)

### DIFF
--- a/SqlScriptDom/Parser/TSql/CodeGenerationSupporter.cs
+++ b/SqlScriptDom/Parser/TSql/CodeGenerationSupporter.cs
@@ -1,4 +1,4 @@
-﻿//------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 // <copyright file="CodeGenerationSupporter.cs" company="Microsoft">
 //         Copyright (c) Microsoft Corporation.  All rights reserved.
 // </copyright>
@@ -972,6 +972,7 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom
         internal const string Signature = "SIGNATURE";
         internal const string SimilarTo = "SIMILAR_TO";
         internal const string Simple = "SIMPLE";
+        internal const string Single = "SINGLE";
         internal const string SingleBlob = "SINGLE_BLOB";
         internal const string SingleClob = "SINGLE_CLOB";
         internal const string SingleNClob = "SINGLE_NCLOB";

--- a/SqlScriptDom/Parser/TSql/OptimizerHintKind.cs
+++ b/SqlScriptDom/Parser/TSql/OptimizerHintKind.cs
@@ -59,6 +59,9 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom
 
         NoPerformanceSpool          = 34,
         Label = 35,
+        ForceSingleNodePlan         = 36,
+        ForceDistributedPlan        = 37,
+        ForTimestampAsOf            = 38,
     }
 
 #pragma warning restore 1591

--- a/SqlScriptDom/Parser/TSql/TSql170.g
+++ b/SqlScriptDom/Parser/TSql/TSql170.g
@@ -22150,6 +22150,7 @@ hint returns [OptimizerHint vResult]
     | vResult = optimizeForOptimizerHint
     | vResult = tableHintsOptimizerHint
     | vResult = useHintClause
+    | vResult = forTimestampAsOfOptimizerHint
     ;
 
 tableHintsOptimizerHint returns [TableHintsOptimizerHint vResult = FragmentFactory.CreateFragment<TableHintsOptimizerHint>()]
@@ -22191,12 +22192,31 @@ simpleOptimizerHint returns [OptimizerHint vResult = FragmentFactory.CreateFragm
             vResult.HintKind = OptimizerHintKind.MergeUnion;
             UpdateTokenInfo(vResult, tMergeUnion); 
         }
-    | tForce:Identifier Order
-        {
-            Match(tForce, CodeGenerationSupporter.Force);
-            vResult.HintKind = OptimizerHintKind.ForceOrder;
-            UpdateTokenInfo(vResult, tForce); 
-        }
+    | {NextTokenMatches(CodeGenerationSupporter.Force)}?
+      tForce:Identifier (
+          Order
+          {
+              Match(tForce, CodeGenerationSupporter.Force);
+              vResult.HintKind = OptimizerHintKind.ForceOrder;
+              UpdateTokenInfo(vResult, tForce); 
+          }
+          |
+          Distributed tPlan1:Plan
+          {
+              Match(tForce, CodeGenerationSupporter.Force);
+              vResult.HintKind = OptimizerHintKind.ForceDistributedPlan;
+              UpdateTokenInfo(vResult, tForce); 
+          }
+          |
+          tSingle:Identifier tNode:Identifier tPlan2:Plan
+          {
+              Match(tForce, CodeGenerationSupporter.Force);
+              Match(tSingle, CodeGenerationSupporter.Single);
+              Match(tNode, CodeGenerationSupporter.GraphNode); // NODE
+              vResult.HintKind = OptimizerHintKind.ForceSingleNodePlan;
+              UpdateTokenInfo(vResult, tForce); 
+          }
+      )
     | tHash:Identifier Group
         {
             Match(tHash, CodeGenerationSupporter.Hash);
@@ -22371,6 +22391,19 @@ useHintClause returns [UseHintList vResult = FragmentFactory.CreateFragment<UseH
             UpdateTokenInfo(vResult, tRParen);
         }
 
+    ;
+
+forTimestampAsOfOptimizerHint returns [LiteralOptimizerHint vResult = FragmentFactory.CreateFragment<LiteralOptimizerHint>()]
+{
+    Literal vValue;
+}
+    : tFor:For tTimestamp:Identifier tAs:As tOf:Of vValue = stringLiteral
+        {
+            Match(tTimestamp, CodeGenerationSupporter.TimeStamp);
+            vResult.HintKind = OptimizerHintKind.ForTimestampAsOf;
+            vResult.Value = vValue;
+            UpdateTokenInfo(vResult, tFor);
+        }
     ;
 
 createRuleStatement returns [CreateRuleStatement vResult = this.FragmentFactory.CreateFragment<CreateRuleStatement>()]

--- a/SqlScriptDom/Parser/TSql/TSql180.g
+++ b/SqlScriptDom/Parser/TSql/TSql180.g
@@ -22379,6 +22379,7 @@ hint returns [OptimizerHint vResult]
     | vResult = optimizeForOptimizerHint
     | vResult = tableHintsOptimizerHint
     | vResult = useHintClause
+    | vResult = forTimestampAsOfOptimizerHint
     ;
 
 tableHintsOptimizerHint returns [TableHintsOptimizerHint vResult = FragmentFactory.CreateFragment<TableHintsOptimizerHint>()]
@@ -22420,12 +22421,31 @@ simpleOptimizerHint returns [OptimizerHint vResult = FragmentFactory.CreateFragm
             vResult.HintKind = OptimizerHintKind.MergeUnion;
             UpdateTokenInfo(vResult, tMergeUnion); 
         }
-    | tForce:Identifier Order
-        {
-            Match(tForce, CodeGenerationSupporter.Force);
-            vResult.HintKind = OptimizerHintKind.ForceOrder;
-            UpdateTokenInfo(vResult, tForce); 
-        }
+    | {NextTokenMatches(CodeGenerationSupporter.Force)}?
+      tForce:Identifier (
+          Order
+          {
+              Match(tForce, CodeGenerationSupporter.Force);
+              vResult.HintKind = OptimizerHintKind.ForceOrder;
+              UpdateTokenInfo(vResult, tForce); 
+          }
+          |
+          Distributed tPlan1:Plan
+          {
+              Match(tForce, CodeGenerationSupporter.Force);
+              vResult.HintKind = OptimizerHintKind.ForceDistributedPlan;
+              UpdateTokenInfo(vResult, tForce); 
+          }
+          |
+          tSingle:Identifier tNode:Identifier tPlan2:Plan
+          {
+              Match(tForce, CodeGenerationSupporter.Force);
+              Match(tSingle, CodeGenerationSupporter.Single);
+              Match(tNode, CodeGenerationSupporter.GraphNode); // NODE
+              vResult.HintKind = OptimizerHintKind.ForceSingleNodePlan;
+              UpdateTokenInfo(vResult, tForce); 
+          }
+      )
     | tHash:Identifier Group
         {
             Match(tHash, CodeGenerationSupporter.Hash);
@@ -22600,6 +22620,19 @@ useHintClause returns [UseHintList vResult = FragmentFactory.CreateFragment<UseH
             UpdateTokenInfo(vResult, tRParen);
         }
 
+    ;
+
+forTimestampAsOfOptimizerHint returns [LiteralOptimizerHint vResult = FragmentFactory.CreateFragment<LiteralOptimizerHint>()]
+{
+    Literal vValue;
+}
+    : tFor:For tTimestamp:Identifier tAs:As tOf:Of vValue = stringLiteral
+        {
+            Match(tTimestamp, CodeGenerationSupporter.TimeStamp);
+            vResult.HintKind = OptimizerHintKind.ForTimestampAsOf;
+            vResult.Value = vValue;
+            UpdateTokenInfo(vResult, tFor);
+        }
     ;
 
 createRuleStatement returns [CreateRuleStatement vResult = this.FragmentFactory.CreateFragment<CreateRuleStatement>()]

--- a/SqlScriptDom/Parser/TSql/TSqlFabricDW.g
+++ b/SqlScriptDom/Parser/TSql/TSqlFabricDW.g
@@ -21910,6 +21910,7 @@ hint returns [OptimizerHint vResult]
     | vResult = optimizeForOptimizerHint
     | vResult = tableHintsOptimizerHint
     | vResult = useHintClause
+    | vResult = forTimestampAsOfOptimizerHint
     ;
 
 tableHintsOptimizerHint returns [TableHintsOptimizerHint vResult = FragmentFactory.CreateFragment<TableHintsOptimizerHint>()]
@@ -21951,12 +21952,31 @@ simpleOptimizerHint returns [OptimizerHint vResult = FragmentFactory.CreateFragm
             vResult.HintKind = OptimizerHintKind.MergeUnion;
             UpdateTokenInfo(vResult, tMergeUnion); 
         }
-    | tForce:Identifier Order
-        {
-            Match(tForce, CodeGenerationSupporter.Force);
-            vResult.HintKind = OptimizerHintKind.ForceOrder;
-            UpdateTokenInfo(vResult, tForce); 
-        }
+    | {NextTokenMatches(CodeGenerationSupporter.Force)}?
+      tForce:Identifier (
+          Order
+          {
+              Match(tForce, CodeGenerationSupporter.Force);
+              vResult.HintKind = OptimizerHintKind.ForceOrder;
+              UpdateTokenInfo(vResult, tForce); 
+          }
+          |
+          Distributed tPlan1:Plan
+          {
+              Match(tForce, CodeGenerationSupporter.Force);
+              vResult.HintKind = OptimizerHintKind.ForceDistributedPlan;
+              UpdateTokenInfo(vResult, tForce); 
+          }
+          |
+          tSingle:Identifier tNode:Identifier tPlan2:Plan
+          {
+              Match(tForce, CodeGenerationSupporter.Force);
+              Match(tSingle, CodeGenerationSupporter.Single);
+              Match(tNode, CodeGenerationSupporter.GraphNode); // NODE
+              vResult.HintKind = OptimizerHintKind.ForceSingleNodePlan;
+              UpdateTokenInfo(vResult, tForce); 
+          }
+      )
     | tHash:Identifier Group
         {
             Match(tHash, CodeGenerationSupporter.Hash);
@@ -22131,6 +22151,19 @@ useHintClause returns [UseHintList vResult = FragmentFactory.CreateFragment<UseH
             UpdateTokenInfo(vResult, tRParen);
         }
 
+    ;
+
+forTimestampAsOfOptimizerHint returns [LiteralOptimizerHint vResult = FragmentFactory.CreateFragment<LiteralOptimizerHint>()]
+{
+    Literal vValue;
+}
+    : tFor:For tTimestamp:Identifier tAs:As tOf:Of vValue = stringLiteral
+        {
+            Match(tTimestamp, CodeGenerationSupporter.TimeStamp);
+            vResult.HintKind = OptimizerHintKind.ForTimestampAsOf;
+            vResult.Value = vValue;
+            UpdateTokenInfo(vResult, tFor);
+        }
     ;
 
 createRuleStatement returns [CreateRuleStatement vResult = this.FragmentFactory.CreateFragment<CreateRuleStatement>()]

--- a/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGeneratorVisitor.OptimizerHint.cs
+++ b/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGeneratorVisitor.OptimizerHint.cs
@@ -105,7 +105,16 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom.ScriptGenerator
                     new IdentifierGenerator(CodeGenerationSupporter.NoPerformanceSpool), }},
                { OptimizerHintKind.Label, new List<TokenGenerator>() {
                     new IdentifierGenerator(CodeGenerationSupporter.Label, true),
-                    new KeywordGenerator(TSqlTokenType.EqualsSign) }}
+                    new KeywordGenerator(TSqlTokenType.EqualsSign) }},
+               { OptimizerHintKind.ForceSingleNodePlan, new List<TokenGenerator>( ) {
+                    new IdentifierGenerator(CodeGenerationSupporter.Force, true),
+                    new IdentifierGenerator(CodeGenerationSupporter.Single, true),
+                    new IdentifierGenerator(CodeGenerationSupporter.GraphNode, true),
+                    new KeywordGenerator(TSqlTokenType.Plan) }},
+               { OptimizerHintKind.ForceDistributedPlan, new List<TokenGenerator>( ) {
+                    new IdentifierGenerator(CodeGenerationSupporter.Force, true),
+                    new KeywordGenerator(TSqlTokenType.Distributed, true),
+                    new KeywordGenerator(TSqlTokenType.Plan) }}
        };
 
         public override void ExplicitVisit(LiteralOptimizerHint node)
@@ -121,6 +130,13 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom.ScriptGenerator
                     GenerateKeyword(TSqlTokenType.Use);
                     GenerateSpaceAndKeyword(TSqlTokenType.Plan);
                 }
+            }
+            else if (node.HintKind == OptimizerHintKind.ForTimestampAsOf)
+            {
+                GenerateKeyword(TSqlTokenType.For);
+                GenerateSpaceAndIdentifier(CodeGenerationSupporter.TimeStamp);
+                GenerateSpaceAndKeyword(TSqlTokenType.As);
+                GenerateSpaceAndKeyword(TSqlTokenType.Of);
             }
             else
             {

--- a/Test/SqlDom/Baselines170/FabricQueryHints170.sql
+++ b/Test/SqlDom/Baselines170/FabricQueryHints170.sql
@@ -1,0 +1,21 @@
+SELECT OrderDateKey,
+       SUM(SalesAmount) AS TotalSales
+FROM FactInternetSales
+GROUP BY OrderDateKey
+ORDER BY OrderDateKey
+OPTION (FOR TIMESTAMP AS OF '2024-03-13T19:39:35.28');
+
+SELECT OrderDateKey,
+       SalesAmount
+FROM FactInternetSales
+OPTION (FORCE SINGLE NODE PLAN);
+
+SELECT OrderDateKey,
+       SalesAmount
+FROM FactInternetSales
+OPTION (FORCE DISTRIBUTED PLAN);
+
+SELECT OrderDateKey,
+       SalesAmount
+FROM FactInternetSales
+OPTION (FORCE DISTRIBUTED PLAN, FOR TIMESTAMP AS OF '2024-03-13T19:39:35.28');

--- a/Test/SqlDom/Only170SyntaxTests.cs
+++ b/Test/SqlDom/Only170SyntaxTests.cs
@@ -41,7 +41,7 @@ namespace SqlStudio.Tests.UTSqlScriptDom
             new ParserTest170("VectorSearchCrossApplyTests170.sql", nErrors80: 1, nErrors90: 1, nErrors100: 1, nErrors110: 1, nErrors120: 1, nErrors130: 1, nErrors140: 1, nErrors150: 1, nErrors160: 1),
             // Complex query with VECTOR types - parses syntactically in all versions (optimization fix), but VECTOR type only valid in TSql170
             new ParserTest170("ComplexQueryTests170.sql"),
-            new ParserTest170("FabricQueryHints170.sql"),
+            new ParserTest170("FabricQueryHints170.sql", nErrors80: 4, nErrors90: 4, nErrors100: 4, nErrors110: 4, nErrors120: 4, nErrors130: 4, nErrors140: 4, nErrors150: 4, nErrors160: 4),
             // Comment preservation tests - basic SQL syntax works in all versions
             new ParserTest170("SingleLineCommentTests170.sql"),
             new ParserTest170("MultiLineCommentTests170.sql")

--- a/Test/SqlDom/Only170SyntaxTests.cs
+++ b/Test/SqlDom/Only170SyntaxTests.cs
@@ -41,6 +41,7 @@ namespace SqlStudio.Tests.UTSqlScriptDom
             new ParserTest170("VectorSearchCrossApplyTests170.sql", nErrors80: 1, nErrors90: 1, nErrors100: 1, nErrors110: 1, nErrors120: 1, nErrors130: 1, nErrors140: 1, nErrors150: 1, nErrors160: 1),
             // Complex query with VECTOR types - parses syntactically in all versions (optimization fix), but VECTOR type only valid in TSql170
             new ParserTest170("ComplexQueryTests170.sql"),
+            new ParserTest170("FabricQueryHints170.sql"),
             // Comment preservation tests - basic SQL syntax works in all versions
             new ParserTest170("SingleLineCommentTests170.sql"),
             new ParserTest170("MultiLineCommentTests170.sql")

--- a/Test/SqlDom/ParserErrorsTests.cs
+++ b/Test/SqlDom/ParserErrorsTests.cs
@@ -8202,5 +8202,35 @@ WHEN NOT MATCHED BY SOURCE THEN DELETE OUTPUT inserted.*, deleted.*;";
                 "SELECT TOP 10 WITH TIES WITH APPROXIMATE * FROM MyTable ORDER BY id;",
                 new ParserErrorInfo(24, "SQL46010", "WITH"));
         }
+
+        /// <summary>
+        /// Negative test for Fabric Query Hints - syntax error (TSql170)
+        /// Verifies malformed hints produce expected parser errors
+        /// </summary>
+        [TestMethod]
+        [Priority(0)]
+        [SqlStudioTestCategory(Category.UnitTest)]
+        public void FabricQueryHintsErrorTest170()
+        {
+            // Missing NODE keyword in FORCE SINGLE NODE PLAN
+            ParserTestUtils.ErrorTest170(
+                "SELECT OrderDateKey FROM FactInternetSales OPTION (FORCE SINGLE PLAN);",
+                new ParserErrorInfo(64, "SQL46010", "PLAN"));
+
+            // Missing PLAN keyword in FORCE DISTRIBUTED PLAN
+            ParserTestUtils.ErrorTest170(
+                "SELECT OrderDateKey FROM FactInternetSales OPTION (FORCE DISTRIBUTED);",
+                new ParserErrorInfo(68, "SQL46010", ")"));
+
+            // Non-string literal in FOR TIMESTAMP AS OF
+            ParserTestUtils.ErrorTest170(
+                "SELECT OrderDateKey FROM FactInternetSales OPTION (FOR TIMESTAMP AS OF 12345);",
+                new ParserErrorInfo(71, "SQL46010", "12345"));
+
+            // Missing OF keyword in FOR TIMESTAMP AS OF
+            ParserTestUtils.ErrorTest170(
+                "SELECT OrderDateKey FROM FactInternetSales OPTION (FOR TIMESTAMP AS '2024-03-13T19:39:35.28');",
+                new ParserErrorInfo(68, "SQL46010", "'2024-03-13T19:39:35.28'"));
+        }
     }
 }

--- a/Test/SqlDom/TestScripts/FabricQueryHints170.sql
+++ b/Test/SqlDom/TestScripts/FabricQueryHints170.sql
@@ -1,0 +1,17 @@
+SELECT OrderDateKey, SUM(SalesAmount) AS TotalSales
+FROM FactInternetSales
+GROUP BY OrderDateKey
+ORDER BY OrderDateKey
+OPTION (FOR TIMESTAMP AS OF '2024-03-13T19:39:35.28');
+
+SELECT OrderDateKey, SalesAmount
+FROM FactInternetSales
+OPTION (FORCE SINGLE NODE PLAN);
+
+SELECT OrderDateKey, SalesAmount
+FROM FactInternetSales
+OPTION (FORCE DISTRIBUTED PLAN);
+
+SELECT OrderDateKey, SalesAmount
+FROM FactInternetSales
+OPTION (FORCE DISTRIBUTED PLAN, FOR TIMESTAMP AS OF '2024-03-13T19:39:35.28');


### PR DESCRIPTION
# Description

Fixes #180.

Adds support for MS Fabric query hints (`FOR TIMESTAMP AS OF '<literal>'`, `FORCE SINGLE NODE PLAN`, and `FORCE DISTRIBUTED PLAN`) in `TSql170Parser`, `TSql180Parser`, and `TSqlFabricDWParser`. These hints are mapped to AST enums (`ForceSingleNodePlan`, `ForceDistributedPlan`, `ForTimestampAsOf`) and handled appropriately in the T-SQL parser grammar and script generator visitor. Includes new regression unit test coverage.

# Code Changes

- [x] [Unit tests](https://github.com/microsoft/SqlScriptDOM/tree/main/Test) are added, if possible
- [x] Existing [tests are passing](https://github.com/microsoft/SqlScriptDOM/blob/main/CONTRIBUTING.md#running-the-tests)
- [x] New or updated code follows the guidelines [here](https://github.com/microsoft/SqlScriptDOM/blob/main/CONTRIBUTING.md#helpful-notes-for-sqldom-extensions)