### PR TITLE
Fix CopyOption FirstTokenIndex and LastTokenIndex (#179)

### DIFF
--- a/SqlScriptDom/Parser/TSql/TSql130.g
+++ b/SqlScriptDom/Parser/TSql/TSql130.g
@@ -22607,16 +22607,19 @@ copyOption [ref Int32 encountered] returns [CopyOption vResult = FragmentFactory
     {
         vResult.Kind = CopyIdentifierOrValueOptionsHelper.Instance.ParseOption(tOption);
         CheckCopyOptionDuplication(ref encountered, vResult.Kind, tOption);
+        UpdateTokenInfo(vResult, tOption);
     }
     | tIdentityInsert:IdentityInsert
     {
         vResult.Kind = CopyOptionKind.Identity_Insert;
         CheckCopyOptionDuplication(ref encountered, vResult.Kind, tIdentityInsert);
+        UpdateTokenInfo(vResult, tIdentityInsert);
     }
     | tCredential:Credential
     {
         vResult.Kind = CopyOptionKind.Credential;
         CheckCopyOptionDuplication(ref encountered, vResult.Kind, tCredential);
+        UpdateTokenInfo(vResult, tCredential);
     }
     )
     EqualsSign
@@ -22624,6 +22627,7 @@ copyOption [ref Int32 encountered] returns [CopyOption vResult = FragmentFactory
     vValue = singleValueTypeCopyOption
     {
         CopyIdentifierOrValueOptionsHelper.Instance.AssignValueToCopyOption(vResult, (SingleValueTypeCopyOption) vValue);
+        vResult.UpdateTokenInfo(vValue);
     }
     |
     vValue = copyCredentialOption
@@ -22632,6 +22636,7 @@ copyOption [ref Int32 encountered] returns [CopyOption vResult = FragmentFactory
         CopyIdentifierOrValueOptionsHelper.Instance.ValidateCopyCredential((CopyCredentialOption)vValue))
         {
             vResult.Value = (CopyCredentialOption) vValue;
+            vResult.UpdateTokenInfo(vValue);
         }
         else
         {

--- a/Test/SqlDom/TSqlParserTest.cs
+++ b/Test/SqlDom/TSqlParserTest.cs
@@ -649,6 +649,45 @@ EXPAND VIEWS)";
             }
         }
 
+        [TestMethod]
+        [Priority(0)]
+        [Timeout(GlobalConstants.DefaultTestTimeout)]
+        [SqlStudioTestCategory(Category.UnitTest)]
+        public void CopyOptionFirstTokenIndexTest()
+        {
+            string input = @"
+COPY INTO #Test
+FROM 'https://xxxx.blob.core.windows.net/raw/'
+WITH (
+    FILE_TYPE = 'CSV',
+    IDENTITY_INSERT = 'ON'
+);";
+            TSql130Parser parser = new TSql130Parser(true);
+            IList<ParseError> errors;
+            TSqlScript script = (TSqlScript)parser.Parse(new System.IO.StringReader(input), out errors);
+            Assert.AreEqual(0, errors.Count);
+
+            var copyStatement = script.Batches[0].Statements[0] as CopyStatement;
+            Assert.IsNotNull(copyStatement);
+            Assert.AreEqual(2, copyStatement.Options.Count);
+
+            // Verify first option: FILE_TYPE = 'CSV'
+            var option1 = copyStatement.Options[0];
+            Assert.AreEqual(CopyOptionKind.File_Type, option1.Kind);
+            // First token should be FILE_TYPE
+            Assert.AreEqual("FILE_TYPE", option1.ScriptTokenStream[option1.FirstTokenIndex].Text);
+            // Last token should be 'CSV'
+            Assert.AreEqual("'CSV'", option1.ScriptTokenStream[option1.LastTokenIndex].Text);
+
+            // Verify second option: IDENTITY_INSERT = 'ON'
+            var option2 = copyStatement.Options[1];
+            Assert.AreEqual(CopyOptionKind.Identity_Insert, option2.Kind);
+            // First token should be IDENTITY_INSERT
+            Assert.AreEqual("IDENTITY_INSERT", option2.ScriptTokenStream[option2.FirstTokenIndex].Text);
+            // Last token should be 'ON'
+            Assert.AreEqual("'ON'", option2.ScriptTokenStream[option2.LastTokenIndex].Text);
+        }
+
         void VerifyTokenTypesAndOffsets(IList<TSqlParserToken> tokens, TSqlTokenType[] tokenTypes, int[] zeroBasedTokenOffsets, int offsetShift)
         {
             Assert.AreEqual<int>(tokenTypes.Length, tokens.Count);


### PR DESCRIPTION
# Description

Fixes #179.

Adds missing `UpdateTokenInfo` calls on the `CopyOption` fragment in the `copyOption` parser rule in `TSql130.g`. This ensures that parsed `CopyOption` AST nodes correctly populate their token location boundaries, setting `FirstTokenIndex` pointing to the option identifier (e.g. `FILE_TYPE`, `IDENTITY_INSERT`, `CREDENTIAL`) rather than their value, and `LastTokenIndex` pointing to the end of the option value. Also adds a targeted unit test verifying these token boundaries.

# Code Changes

- [x] [Unit tests](https://github.com/microsoft/SqlScriptDOM/tree/main/Test) are added, if possible
- [x] Existing [tests are passing](https://github.com/microsoft/SqlScriptDOM/blob/main/CONTRIBUTING.md#running-the-tests)
- [x] New or updated code follows the guidelines [here](https://github.com/microsoft/SqlScriptDOM/blob/main/CONTRIBUTING.md#helpful-notes-for-sqldom-extensions)