### PR TITLE
Make MODEL_TYPE fragment classification non-breaking

### DIFF
--- a/SqlScriptDom/Parser/TSql/Ast.xml
+++ b/SqlScriptDom/Parser/TSql/Ast.xml
@@ -1388,7 +1388,8 @@
     <Member Name="Name" Type="Identifier" Summary="The external model name."/>
     <Member Name="Location" Type="Literal" Summary="The external model location name."/>
     <Member Name="ApiFormat" Type="Literal" Summary="The external model api format name."/>
-    <Member Name="ModelType" Type="ExternalModelTypeOption" Summary="The external model type name."/>
+    <Member Name="ModelType" Type="ExternalModelTypeOption?" GenerateUpdatePositionInfoCall="false" Summary="The external model type name. Retained for backward compatibility; prefer ModelTypeSpecification."/>
+    <Member Name="ModelTypeSpecification" Type="ExternalModelTypeSpecification" Summary="The MODEL_TYPE option as a visitable fragment."/>
     <Member Name="ModelName" Type="Literal" Summary="The external model name to be used to generate embeddings."/>
     <Member Name="Credential" Type="Identifier" Summary="The external model credentials name."/>
     <Member Name="Parameters" Type="Literal" Summary="The external model parameters as key-value pairs."/>
@@ -1404,8 +1405,8 @@
   <Class Name="AlterExternalModelStatement" Base="ExternalModelStatement" Summary="Represents a ALTER EXTERNAL MODEL statement.">
     <InheritedClass Name="ExternalModelStatement"/>
   </Class>
-  <Class Name="ExternalModelTypeOption" Base="TSqlFragment" Summary="Represents the MODEL_TYPE option in CREATE/ALTER EXTERNAL MODEL.">
-    <Member Name="OptionKind" Type="ExternalModelTypeOptionKind" GenerateUpdatePositionInfoCall="false" Summary="The option kind."/>
+  <Class Name="ExternalModelTypeSpecification" Base="TSqlFragment" Summary="Represents the MODEL_TYPE option in CREATE/ALTER EXTERNAL MODEL.">
+    <Member Name="OptionKind" Type="ExternalModelTypeOption" GenerateUpdatePositionInfoCall="false" Summary="The option kind."/>
   </Class>
 
   <Class Name="ExternalFileFormatStatement" Abstract="true" Base="TSqlStatement" Summary="Base class for all external file format statement objects.">

--- a/SqlScriptDom/Parser/TSql/ExternalModelTypeOption.cs
+++ b/SqlScriptDom/Parser/TSql/ExternalModelTypeOption.cs
@@ -10,16 +10,15 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom
 #pragma warning disable 1591
 
     /// <summary>
-    /// The enumeration specifies the external model type
-    /// Currently, we support Embeddings only.
+    /// The enumeration specifies the external model type.
+    /// Currently, we support EMBEDDINGS only.
     /// </summary>
-    public enum ExternalModelTypeOptionKind
+    public enum ExternalModelTypeOption
     {
         /// <summary>
         /// MODEL_TYPE = EMBEDDINGS
         /// </summary>
-        Embeddings = 0,
-
+        EMBEDDINGS = 0,
     }
 
 #pragma warning restore 1591

--- a/SqlScriptDom/Parser/TSql/TSql170.g
+++ b/SqlScriptDom/Parser/TSql/TSql170.g
@@ -24171,14 +24171,14 @@ StringLiteral vApiFormat;
 
 externalModelModelType[ExternalModelStatement vParent]
 {
-    ExternalModelTypeOption vModelTypeOption = null;
+    ExternalModelTypeSpecification vModelTypeSpec = null;
 }
   :
         tModelType:Identifier
         {
             Match(tModelType, CodeGenerationSupporter.ModelType);
-            vModelTypeOption = this.FragmentFactory.CreateFragment<ExternalModelTypeOption>();
-            UpdateTokenInfo(vModelTypeOption, tModelType);
+            vModelTypeSpec = this.FragmentFactory.CreateFragment<ExternalModelTypeSpecification>();
+            UpdateTokenInfo(vModelTypeSpec, tModelType);
         }
         EqualsSign
         (
@@ -24186,10 +24186,11 @@ externalModelModelType[ExternalModelStatement vParent]
             {
                 if (TryMatch(tEmbeddings, CodeGenerationSupporter.Embeddings))
                 {
-                    vModelTypeOption.OptionKind = ExternalModelTypeOptionKind.Embeddings;
-                    UpdateTokenInfo(vModelTypeOption, tEmbeddings);
-                    vParent.ModelType = vModelTypeOption;
-                    vParent.UpdateTokenInfo(vModelTypeOption);
+                    vModelTypeSpec.OptionKind = ExternalModelTypeOption.EMBEDDINGS;
+                    UpdateTokenInfo(vModelTypeSpec, tEmbeddings);
+                    vParent.ModelTypeSpecification = vModelTypeSpec;
+                    vParent.ModelType = ExternalModelTypeOption.EMBEDDINGS;
+                    vParent.UpdateTokenInfo(vModelTypeSpec);
                 }
                 else
                 {

--- a/SqlScriptDom/Parser/TSql/TSql180.g
+++ b/SqlScriptDom/Parser/TSql/TSql180.g
@@ -24400,14 +24400,14 @@ StringLiteral vApiFormat;
 
 externalModelModelType[ExternalModelStatement vParent]
 {
-    ExternalModelTypeOption vModelTypeOption = null;
+    ExternalModelTypeSpecification vModelTypeSpec = null;
 }
   :
         tModelType:Identifier
         {
             Match(tModelType, CodeGenerationSupporter.ModelType);
-            vModelTypeOption = this.FragmentFactory.CreateFragment<ExternalModelTypeOption>();
-            UpdateTokenInfo(vModelTypeOption, tModelType);
+            vModelTypeSpec = this.FragmentFactory.CreateFragment<ExternalModelTypeSpecification>();
+            UpdateTokenInfo(vModelTypeSpec, tModelType);
         }
         EqualsSign
         (
@@ -24415,10 +24415,11 @@ externalModelModelType[ExternalModelStatement vParent]
             {
                 if (TryMatch(tEmbeddings, CodeGenerationSupporter.Embeddings))
                 {
-                    vModelTypeOption.OptionKind = ExternalModelTypeOptionKind.Embeddings;
-                    UpdateTokenInfo(vModelTypeOption, tEmbeddings);
-                    vParent.ModelType = vModelTypeOption;
-                    vParent.UpdateTokenInfo(vModelTypeOption);
+                    vModelTypeSpec.OptionKind = ExternalModelTypeOption.EMBEDDINGS;
+                    UpdateTokenInfo(vModelTypeSpec, tEmbeddings);
+                    vParent.ModelTypeSpecification = vModelTypeSpec;
+                    vParent.ModelType = ExternalModelTypeOption.EMBEDDINGS;
+                    vParent.UpdateTokenInfo(vModelTypeSpec);
                 }
                 else
                 {

--- a/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGenerator.AlterExternalModelStatement.cs
+++ b/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGenerator.AlterExternalModelStatement.cs
@@ -53,7 +53,7 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom.ScriptGenerator
             }
 
             // external model Model Type options
-            if (node.ModelType != null)
+            if (node.ModelTypeSpecification != null)
             {
                 if (!ifFirst)
                 {
@@ -61,7 +61,18 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom.ScriptGenerator
                 }
                 ifFirst = false;
                 NewLine();
-                GenerateFragmentIfNotNull(node.ModelType);
+                GenerateFragmentIfNotNull(node.ModelTypeSpecification);
+            }
+            else if (node.ModelType != null)
+            {
+                if (!ifFirst)
+                {
+                    GenerateSymbol(TSqlTokenType.Comma);
+                }
+                ifFirst = false;
+                NewLine();
+                string externalModelTypeOption = GetValueForEnumKey(_externalModelTypeOption, node.ModelType.Value);
+                GenerateNameEqualsValue(CodeGenerationSupporter.ModelType, externalModelTypeOption);
             }
 
             // external model name options

--- a/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGeneratorVisitor.CreateExternalModelStatement.cs
+++ b/SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGeneratorVisitor.CreateExternalModelStatement.cs
@@ -17,9 +17,9 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom.ScriptGenerator
             GenerateSpaceAndIdentifier(CodeGenerationSupporter.Model);
             GenerateCreateExternalModelStatementBody(node);
         }
-        protected static Dictionary<ExternalModelTypeOptionKind, string> _externalModelTypeOptionKind = new Dictionary<ExternalModelTypeOptionKind, string>()
+        protected static Dictionary<ExternalModelTypeOption, string> _externalModelTypeOption = new Dictionary<ExternalModelTypeOption, string>()
         {
-            {ExternalModelTypeOptionKind.Embeddings, CodeGenerationSupporter.Embeddings}
+            {ExternalModelTypeOption.EMBEDDINGS, CodeGenerationSupporter.Embeddings}
         };
 
         protected void GenerateCreateExternalModelStatementBody(CreateExternalModelStatement node)
@@ -54,7 +54,7 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom.ScriptGenerator
             }
 
             // external model Model Type options
-            if (node.ModelType != null)
+            if (node.ModelTypeSpecification != null)
             {
                 if (!ifFirst)
                 {
@@ -62,7 +62,18 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom.ScriptGenerator
                 }
                 ifFirst = false;
                 NewLine();
-                GenerateFragmentIfNotNull(node.ModelType);
+                GenerateFragmentIfNotNull(node.ModelTypeSpecification);
+            }
+            else if (node.ModelType != null)
+            {
+                if (!ifFirst)
+                {
+                    GenerateSymbol(TSqlTokenType.Comma);
+                }
+                ifFirst = false;
+                NewLine();
+                string externalModelTypeOption = GetValueForEnumKey(_externalModelTypeOption, node.ModelType.Value);
+                GenerateNameEqualsValue(CodeGenerationSupporter.ModelType, externalModelTypeOption);
             }
 
             // external model name options
@@ -117,9 +128,9 @@ namespace Microsoft.SqlServer.TransactSql.ScriptDom.ScriptGenerator
             GenerateKeyword(TSqlTokenType.RightParenthesis);
         }
 
-        public override void ExplicitVisit(ExternalModelTypeOption node)
+        public override void ExplicitVisit(ExternalModelTypeSpecification node)
         {
-            string optionKindString = GetValueForEnumKey(_externalModelTypeOptionKind, node.OptionKind);
+            string optionKindString = GetValueForEnumKey(_externalModelTypeOption, node.OptionKind);
             GenerateNameEqualsValue(CodeGenerationSupporter.ModelType, optionKindString);
         }
     }

--- a/Test/SqlDom/Only170SyntaxTests.cs
+++ b/Test/SqlDom/Only170SyntaxTests.cs
@@ -407,18 +407,24 @@ namespace SqlStudio.Tests.UTSqlScriptDom
             Assert.IsNotNull(fragment);
             
             // Collect all visited fragments using a custom visitor
-            var visitor = new ExternalModelTypeOptionVisitor();
+            var visitor = new ExternalModelTypeSpecificationVisitor();
             fragment.Accept(visitor);
             
             Assert.AreEqual(1, visitor.VisitedOptions.Count);
-            Assert.AreEqual(ExternalModelTypeOptionKind.Embeddings, visitor.VisitedOptions[0].OptionKind);
+            Assert.AreEqual(ExternalModelTypeOption.EMBEDDINGS, visitor.VisitedOptions[0].OptionKind);
+
+            // Legacy enum member must still be populated for backward compatibility
+            var createStatement = ((TSqlScript)fragment).Batches[0].Statements[0] as CreateExternalModelStatement;
+            Assert.IsNotNull(createStatement);
+            Assert.AreEqual(ExternalModelTypeOption.EMBEDDINGS, createStatement.ModelType);
+            Assert.IsNotNull(createStatement.ModelTypeSpecification);
         }
         
-        private class ExternalModelTypeOptionVisitor : TSqlFragmentVisitor
+        private class ExternalModelTypeSpecificationVisitor : TSqlFragmentVisitor
         {
-            public List<ExternalModelTypeOption> VisitedOptions { get; } = new List<ExternalModelTypeOption>();
+            public List<ExternalModelTypeSpecification> VisitedOptions { get; } = new List<ExternalModelTypeSpecification>();
             
-            public override void Visit(ExternalModelTypeOption node)
+            public override void Visit(ExternalModelTypeSpecification node)
             {
                 VisitedOptions.Add(node);
                 base.Visit(node);


### PR DESCRIPTION
## Summary

Reworks the `MODEL_TYPE` fix so it fixes the fragment-classification bug (#176) **without breaking the public API**.

## Background

Commit [`20f9bf1`](https://github.com/microsoft/SqlScriptDOM/commit/20f9bf1117ec9b4366d2f66165df193ec1b206c8) (PR #210, fixing #176) reclassified `MODEL_TYPE` as a `TSqlFragment`, but did so in a **breaking** way:

- Repurposed the public `enum ExternalModelTypeOption { EMBEDDINGS }` into a `TSqlFragment` class.
- Changed `ExternalModelStatement.ModelType` from `ExternalModelTypeOption?` (nullable enum) to a fragment reference.
- Renamed the enum value `EMBEDDINGS` → `Embeddings` (moved into a new `ExternalModelTypeOptionKind` enum).

Any downstream consumer (e.g. DacFx) referencing `ExternalModelTypeOption.EMBEDDINGS` or reading `ModelType` as an enum would fail to compile.

## What this PR does instead (additive / non-breaking)

- **Keeps** `enum ExternalModelTypeOption { EMBEDDINGS }` and the `ExternalModelStatement.ModelType` (`ExternalModelTypeOption?`) member unchanged for backward compatibility.
- **Adds** a visitable fragment `ExternalModelTypeSpecification` whose `OptionKind` reuses the existing `ExternalModelTypeOption` enum, plus a new `ModelTypeSpecification` member on `ExternalModelStatement`.
- The parser populates **both** representations; the script generator prefers the fragment and falls back to the legacy enum.
- This resolves #176 (MODEL_TYPE is now a proper visitable fragment with real token offsets) while existing enum-based consumers keep compiling.

## Files changed

- `SqlScriptDom/Parser/TSql/Ast.xml`
- `SqlScriptDom/Parser/TSql/ExternalModelTypeOption.cs`
- `SqlScriptDom/Parser/TSql/TSql170.g`, `TSql180.g`
- `SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGeneratorVisitor.CreateExternalModelStatement.cs`
- `SqlScriptDom/ScriptDom/SqlServer/ScriptGenerator/SqlScriptGenerator.AlterExternalModelStatement.cs`
- `Test/SqlDom/Only170SyntaxTests.cs`

## Testing

- Full suite: **624 passed, 0 failed** on both `net8.0` and `net472`.
- Test asserts both the new fragment (`ModelTypeSpecification` / `OptionKind`) and the legacy enum (`ModelType == ExternalModelTypeOption.EMBEDDINGS`) to prove backward compatibility.
